### PR TITLE
11 예외처리 클래스 response 클래스 정의

### DIFF
--- a/src/main/java/com/dev/musiummate/configuration/Response.java
+++ b/src/main/java/com/dev/musiummate/configuration/Response.java
@@ -1,0 +1,19 @@
+package com.dev.musiummate.configuration;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Response<T> {
+    private String resultCode;
+    private T result;
+
+    public static <T> Response error(T data){
+        return new Response("ERROR", data);
+    }
+
+    public static <T> Response success(T data){
+        return new Response("SUCCESS", data);
+    }
+}

--- a/src/main/java/com/dev/musiummate/domain/dto/ErrorResponse.java
+++ b/src/main/java/com/dev/musiummate/domain/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.dev.musiummate.domain.dto;
+
+import com.dev.musiummate.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ErrorResponse {
+    private String errorCode;
+    private String message;
+}

--- a/src/main/java/com/dev/musiummate/exception/AppException.java
+++ b/src/main/java/com/dev/musiummate/exception/AppException.java
@@ -1,0 +1,21 @@
+package com.dev.musiummate.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AppException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String message;
+
+    @Override
+    public String getMessage() {
+        if (message == null) {
+            return errorCode.getMessage();
+        } else {
+            return String.format("%s: %s", errorCode.getMessage(), message);
+        }
+
+    }
+}

--- a/src/main/java/com/dev/musiummate/exception/ErrorCode.java
+++ b/src/main/java/com/dev/musiummate/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.dev.musiummate.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "User name conflict");
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/dev/musiummate/exception/ExceptionManager.java
+++ b/src/main/java/com/dev/musiummate/exception/ExceptionManager.java
@@ -1,0 +1,23 @@
+package com.dev.musiummate.exception;
+
+import com.dev.musiummate.configuration.Response;
+import com.dev.musiummate.domain.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+
+public class ExceptionManager {
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> runTimeExceptionHandler(RuntimeException e){
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("INTERNAL SERVER ERROR");
+    }
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<?> appExceptionHandler(AppException e){
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(Response.error(new ErrorResponse(e.getErrorCode().toString(), e.getMessage())));
+    }
+}


### PR DESCRIPTION
## :information_desk_person: 간단 소개
예외처리 클래스 작성, response 래퍼 클래스 작성

## :heavy_check_mark: 작업 내용 설명
### 예외처리
- 새로운 AppException을 정의하였습니다.
- ExceptionManager 클래스에서 RunTimeException과 AppException 발생시 감지하도록 구성하였습니다.
- ErrorCode ENUM을 정의하였습니다.

### response 래퍼 클래스
response 클래스는 다음과 같이 구성하였습니다. 
```JSON 
{
 "resultCode": ,
 "result": 
}
```

## :bulb: 참고사항
### Response 클래스 관련
**SUCCESS**
Response.success(T)
- 괄호 안에 반환하려는 데이터를 넣습니다.

**ERROR**
에러 발생시 다음과 같은 구조의 JSON이 반환됩니다. `errorCode`는 errorCode 객체를 toString 하였고, `message`는 errorCode객체의 message와 AppException의 message를 조합하였습니다.
```JSON 
{
 "resultCode":"ERROR",
 "result": {
  "errorCode":"DUPLICATE_USERNAME",
  "message":"User name conflict: 지영님은 이미 존재합니다."
 }
}
```