### PR TITLE
27 user entity 수정

### DIFF
--- a/src/main/java/com/dev/musiummate/configuration/JpaAuditingConfiguration.java
+++ b/src/main/java/com/dev/musiummate/configuration/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.dev.musiummate.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/dev/musiummate/domain/UserRole.java
+++ b/src/main/java/com/dev/musiummate/domain/UserRole.java
@@ -1,0 +1,8 @@
+package com.dev.musiummate.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum UserRole {
+    ROLE_USER,ROLE_ADMIN;
+}

--- a/src/main/java/com/dev/musiummate/domain/entity/BaseEntity.java
+++ b/src/main/java/com/dev/musiummate/domain/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.dev.musiummate.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity{
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column
+    private String lastModifiedBy;
+}

--- a/src/main/java/com/dev/musiummate/domain/entity/BaseTimeEntity.java
+++ b/src/main/java/com/dev/musiummate/domain/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.dev.musiummate.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/com/dev/musiummate/domain/entity/UserEntity.java
+++ b/src/main/java/com/dev/musiummate/domain/entity/UserEntity.java
@@ -1,9 +1,7 @@
-package com.dev.musiummate.domain;
+package com.dev.musiummate.domain.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.dev.musiummate.domain.UserRole;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,9 +21,11 @@ public class UserEntity {
     private String birth;
     private String phoneNumber;
     private String address;
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
 
     @Builder
-    public UserEntity(Long id, String email, String password, String userName, String birth, String phoneNumber, String address) {
+    public UserEntity(Long id, String email, String password, String userName, String birth, String phoneNumber, String address, UserRole role) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -33,5 +33,6 @@ public class UserEntity {
         this.birth = birth;
         this.phoneNumber = phoneNumber;
         this.address = address;
+        this.role = role;
     }
 }

--- a/src/main/java/com/dev/musiummate/domain/entity/UserEntity.java
+++ b/src/main/java/com/dev/musiummate/domain/entity/UserEntity.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserEntity {
+public class UserEntity extends BaseEntity{
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/com/dev/musiummate/repository/UserRepository.java
+++ b/src/main/java/com/dev/musiummate/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.dev.musiummate.repository;
 
-import com.dev.musiummate.domain.UserEntity;
+import com.dev.musiummate.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserEntity,Long> {


### PR DESCRIPTION
## :information_desk_person: 간단 소개
user entity 수정에 관한 건입니다.

## :heavy_check_mark: 작업 내용 설명
UserEntity 속성에 role을 추가하였습니다.
BaseEntity(createdBy, lastModifiedBy), BaseTimeEntity(createdAt,lastModifiedAt) 을 작성하고 BaseEntity가 BaseTimeEntity를 상속받도록, UserEntity가 BaseEntity를 상속받도록 했습니다.

## :bulb: 참고사항
**_회원가입할때 UserRole을 정해주는 부분이 추가되어야 할 것 같습니다._**
