### PR TITLE
10 spring security

### DIFF
--- a/src/main/java/com/dev/museummate/controller/ExampleController.java
+++ b/src/main/java/com/dev/museummate/controller/ExampleController.java
@@ -1,0 +1,20 @@
+package com.dev.museummate.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ExampleController {
+
+    // 시큐리티 테스트를 위한 임의의 endpoint
+    @GetMapping("/example/security")
+    public String securityTest(Authentication authentication){
+        return "security test success";
+    }
+
+    @GetMapping("/example/security/admin")
+    public String securityTestAdmin(Authentication authentication){
+        return "security test success";
+    }
+}

--- a/src/main/java/com/dev/museummate/exception/ErrorCode.java
+++ b/src/main/java/com/dev/museummate/exception/ErrorCode.java
@@ -12,6 +12,10 @@ public enum ErrorCode {
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "Post Not Found"),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"email not found"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "invalid password"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Token invalid"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Token expired"),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Token not found"),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "Access forbidden"),
     ;
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/dev/museummate/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/dev/museummate/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package com.dev.museummate.security;
+
+import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.ErrorResponse;
+import com.dev.museummate.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ErrorCode errorCode = ErrorCode.FORBIDDEN_ACCESS;
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+
+        Response errorResponse = Response.error(new ErrorResponse(errorCode.toString(), errorCode.getMessage()));
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/dev/museummate/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dev/museummate/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.dev.museummate.security;
+
+import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.ErrorResponse;
+import com.dev.museummate.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        // 인증이 필요하지만 토큰이 입력되지 않았을 경우
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ErrorCode errorCode = ErrorCode.TOKEN_NOT_FOUND;
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+
+        Response errorResponse = Response.error(new ErrorResponse(errorCode.toString(), errorCode.getMessage()));
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/dev/museummate/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dev/museummate/security/CustomAuthenticationEntryPoint.java
@@ -21,11 +21,13 @@ import java.io.IOException;
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
 
-        // 인증이 필요하지만 토큰이 입력되지 않았을 경우
+        if(errorCode == null){
+            errorCode = ErrorCode.TOKEN_NOT_FOUND;
+        }
+
         ObjectMapper objectMapper = new ObjectMapper();
-
-        ErrorCode errorCode = ErrorCode.TOKEN_NOT_FOUND;
 
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/dev/museummate/security/JwtExceptionFilter.java
+++ b/src/main/java/com/dev/museummate/security/JwtExceptionFilter.java
@@ -25,34 +25,28 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request,response);
         } catch (MalformedJwtException e){
             log.info("손상된 토큰입니다: {}", request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,ErrorCode.INVALID_TOKEN);
+            request.setAttribute("errorCode", ErrorCode.INVALID_TOKEN);
+            filterChain.doFilter(request, response);
         } catch (UnsupportedJwtException e){
             log.info("지원하지 않는 토큰입니다: {}", request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,ErrorCode.INVALID_TOKEN);
+            request.setAttribute("errorCode", ErrorCode.INVALID_TOKEN);
+            filterChain.doFilter(request, response);
         } catch (SignatureException e){
             log.info("시그니처 검증에 실패한 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,ErrorCode.INVALID_TOKEN);
+            request.setAttribute("errorCode", ErrorCode.INVALID_TOKEN);
+            filterChain.doFilter(request, response);
         } catch(ExpiredJwtException e) {
             log.info("만료된 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,ErrorCode.EXPIRED_TOKEN);
+            request.setAttribute("errorCode", ErrorCode.EXPIRED_TOKEN);
+            filterChain.doFilter(request, response);
         } catch (IllegalArgumentException | JwtException e){
             log.info("잘못된 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,ErrorCode.INVALID_TOKEN);
-        } catch (AppException e){   //유저가 존재하지 않는 경우
+            request.setAttribute("errorCode", ErrorCode.INVALID_TOKEN);
+            filterChain.doFilter(request, response);
+        } catch (AppException e){   // 유저가 존재하지 않는 경우
             log.info("App Exception: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
-            setResponse(response,e.getErrorCode());
+            request.setAttribute("errorCode", e.getErrorCode());
+            filterChain.doFilter(request, response);
         }
-    }
-
-    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("utf-8");
-
-        Response errorResponse = Response.error(new ErrorResponse(errorCode.toString(), errorCode.getMessage()));
-
-        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/dev/museummate/security/JwtExceptionFilter.java
+++ b/src/main/java/com/dev/museummate/security/JwtExceptionFilter.java
@@ -1,0 +1,58 @@
+package com.dev.museummate.security;
+
+import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.ErrorResponse;
+import com.dev.museummate.exception.AppException;
+import com.dev.museummate.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            filterChain.doFilter(request,response);
+        } catch (MalformedJwtException e){
+            log.info("손상된 토큰입니다: {}", request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,ErrorCode.INVALID_TOKEN);
+        } catch (UnsupportedJwtException e){
+            log.info("지원하지 않는 토큰입니다: {}", request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,ErrorCode.INVALID_TOKEN);
+        } catch (SignatureException e){
+            log.info("시그니처 검증에 실패한 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,ErrorCode.INVALID_TOKEN);
+        } catch(ExpiredJwtException e) {
+            log.info("만료된 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,ErrorCode.EXPIRED_TOKEN);
+        } catch (IllegalArgumentException | JwtException e){
+            log.info("잘못된 토큰입니다: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,ErrorCode.INVALID_TOKEN);
+        } catch (AppException e){   //유저가 존재하지 않는 경우
+            log.info("App Exception: {}",request.getHeader(HttpHeaders.AUTHORIZATION));
+            setResponse(response,e.getErrorCode());
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+
+        Response errorResponse = Response.error(new ErrorResponse(errorCode.toString(), errorCode.getMessage()));
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/dev/museummate/security/JwtFilter.java
+++ b/src/main/java/com/dev/museummate/security/JwtFilter.java
@@ -1,0 +1,46 @@
+package com.dev.museummate.security;
+
+import com.dev.museummate.utils.JwtUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final String secretKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("header: {}",authorizationHeader);
+        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request,response);
+            return;
+        }
+
+        String token = extractToken(authorizationHeader);
+
+        UsernamePasswordAuthenticationToken authenticationToken = jwtUtils.getAuthentication(token, secretKey);
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        filterChain.doFilter(request,response);
+    }
+
+    private String extractToken(String authorizationHeader) {
+        return authorizationHeader.split(" ")[1];
+    }
+}

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -34,6 +34,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/users/join","/users/login").permitAll()
                         .requestMatchers(HttpMethod.GET,"/example/security").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/example/security/admin").hasRole("ADMIN")
                         .anyRequest().permitAll()   //고정
                 )
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
@@ -32,10 +33,15 @@ public class SecurityConfiguration {
                 .and()
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/users/join","/users/login").permitAll()
-                        .requestMatchers(HttpMethod.POST).authenticated())
-//                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-//                .and()
-//                .addFilterBefore(new JwtFilter(jwtUtils, secretKey), UsernamePasswordAuthenticationFilter.class)
+                        .requestMatchers(HttpMethod.GET,"/example/security").authenticated()
+                        .anyRequest().permitAll()   //고정
+                )
+                .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())
+                .and()
+                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .and()
+                .addFilterBefore(new JwtFilter(jwtUtils, secretKey), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/dev/museummate/service/UserService.java
+++ b/src/main/java/com/dev/museummate/service/UserService.java
@@ -22,6 +22,11 @@ public class UserService {
 
     private long accessExpireTimeMs = 1000 * 60 * 5;
 
+    public UserEntity findUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() ->
+                new AppException(ErrorCode.EMAIL_NOT_FOUND, String.format("%s님은 존재하지 않습니다.",email)));
+    }
+
     public UserJoinResponse join(UserJoinRequest userJoinRequest) {
 
         userRepository.findByUserName(userJoinRequest.getUserName())
@@ -58,4 +63,6 @@ public class UserService {
         return new UserLoginResponse(accessToken);
 
     }
+
+
 }

--- a/src/main/java/com/dev/museummate/utils/JwtUtils.java
+++ b/src/main/java/com/dev/museummate/utils/JwtUtils.java
@@ -1,13 +1,18 @@
 package com.dev.museummate.utils;
 
+import com.dev.museummate.domain.entity.UserEntity;
 import com.dev.museummate.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+
+import java.util.List;
 
 
 @Component
@@ -32,6 +37,17 @@ public class JwtUtils {
                 .setExpiration(new Date(System.currentTimeMillis() + expiredTimeMs))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
+    }
+
+    private UserEntity getUser(String token, String secretKey){
+        String email = extractClaims(token, secretKey).get("email").toString();
+        UserEntity userEntity = userService.findUserByEmail(email);
+        return userEntity;
+    }
+    public UsernamePasswordAuthenticationToken getAuthentication(String token, String secretKey) {
+        UserEntity userEntity = getUser(token,secretKey);
+        return new UsernamePasswordAuthenticationToken(userEntity.getEmail(),
+                null, List.of(new SimpleGrantedAuthority(userEntity.getRole().name())));
     }
 
 }

--- a/src/test/java/com/dev/museummate/fixture/UserEntityFixture.java
+++ b/src/test/java/com/dev/museummate/fixture/UserEntityFixture.java
@@ -1,0 +1,29 @@
+package com.dev.museummate.fixture;
+
+import com.dev.museummate.domain.UserRole;
+import com.dev.museummate.domain.entity.UserEntity;
+
+public class UserEntityFixture {
+
+    public static UserEntity getUser(String email, String password) {
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .role(UserRole.ROLE_USER)
+                .build();
+
+        return user;
+    }
+
+    public static UserEntity getAdmin(String email, String password) {
+        UserEntity admin = UserEntity.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .role(UserRole.ROLE_ADMIN)
+                .build();
+
+        return admin;
+    }
+}

--- a/src/test/java/com/dev/museummate/security/SecurityFilterTest.java
+++ b/src/test/java/com/dev/museummate/security/SecurityFilterTest.java
@@ -1,0 +1,137 @@
+package com.dev.museummate.security;
+
+import com.dev.museummate.controller.ExampleController;
+import com.dev.museummate.domain.entity.UserEntity;
+import com.dev.museummate.fixture.UserEntityFixture;
+import com.dev.museummate.service.UserService;
+import com.dev.museummate.utils.JwtUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = ExampleController.class)
+@ImportAutoConfiguration(classes = {SecurityConfiguration.class, JwtUtils.class})
+public class SecurityFilterTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UserService userService;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private UserEntity user;
+    private UserEntity admin;
+
+    private String createToken(UserEntity userEntity, long expiredMs){
+        return JwtUtils.createAccessToken(userEntity.getEmail(), secretKey, expiredMs);
+    }
+
+    @BeforeEach
+    void setUp(){
+        user = UserEntityFixture.getUser("user_email","user_password");
+        admin = UserEntityFixture.getAdmin("admin_email","admin_password");
+    }
+
+    @Test
+    @DisplayName("인증 성공 테스트")
+    void authenticationSuccess() throws Exception {
+        String token = createToken(user,1000 * 60);
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(get("/example/security")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(content().string("security test success"))
+                .andDo(print());
+    }
+
+
+    @Test
+    @DisplayName("인증 실패 테스트 - 만료된 토큰")
+    void authenticationFailExpired() throws Exception {
+        String token = createToken(user,1);
+
+        mockMvc.perform(get("/example/security")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("ERROR"))
+                .andExpect(jsonPath("$.result.errorCode").value("EXPIRED_TOKEN"))
+                .andExpect(jsonPath("$.result.message").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("인증 실패 테스트 - 토큰 없음")
+    void authenticationFailNull() throws Exception {
+
+        mockMvc.perform(get("/example/security"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("ERROR"))
+                .andExpect(jsonPath("$.result.errorCode").value("TOKEN_NOT_FOUND"))
+                .andExpect(jsonPath("$.result.message").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("인증 실패 테스트 - 적절하지 않은 토큰(MalformedJwtException)")
+    void authenticationFailWrong() throws Exception {
+        String token = "abc";
+
+        mockMvc.perform(get("/example/security")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("ERROR"))
+                .andExpect(jsonPath("$.result.errorCode").value("INVALID_TOKEN"))
+                .andExpect(jsonPath("$.result.message").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("접근 성공 테스트 - admin 회원이 전용 페이지에 접근하는 경우")
+    void accessSuccess() throws Exception {
+        String token = createToken(admin,1000 * 60);
+
+        when(userService.findUserByEmail(any())).thenReturn(admin);
+
+
+        mockMvc.perform(get("/example/security/admin")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(content().string("security test success"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("접근 실패 테스트 - admin 회원 전용 페이지에 user 회원이 접근하는 경우")
+    void accessDenied() throws Exception {
+        String token = createToken(user,1000 * 60);
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+
+        mockMvc.perform(get("/example/security/admin")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.resultCode").value("ERROR"))
+                .andExpect(jsonPath("$.result.errorCode").value("FORBIDDEN_ACCESS"))
+                .andExpect(jsonPath("$.result.message").exists())
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/dev/museummate/security/SecurityFilterTest.java
+++ b/src/test/java/com/dev/museummate/security/SecurityFilterTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -134,4 +135,76 @@ public class SecurityFilterTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("MethodNotAllowed 테스트 - 허용되지 않은 Http Method로 접근한 경우: 토큰 있을 때")
+    void MethodNotAllowed() throws Exception {
+        String token = createToken(user,1000 * 60);
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(post("/example/security")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isMethodNotAllowed())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("MethodNotAllowed 테스트 - 허용되지 않은 Http Method로 접근한 경우: 토큰 없을 때")
+    void MethodNotAllowed2() throws Exception {
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(post("/example/security"))
+                .andExpect(status().isMethodNotAllowed())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("MethodNotAllowed 테스트 - 허용되지 않은 Http Method로 접근한 경우: 토큰 적절하지 않을 때")
+    void MethodNotAllowed3() throws Exception {
+        String token = "abc";
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(post("/example/security")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isMethodNotAllowed())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("NotFound 테스트 - 정의되지 않은 url에 접근한 경우: 토큰 있을 때")
+    void NotFound() throws Exception {
+        String token = createToken(user,1000 * 60);
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(get("/notDefinedUrl")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("NotFound 테스트 - 정의되지 않은 url에 접근한 경우: 토큰 없을 때")
+    void NotFound2() throws Exception {
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(get("/notDefinedUrl"))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("NotFound 테스트 - 정의되지 않은 url에 접근한 경우: 토큰 적절하지 않을 때")
+    void NotFound3() throws Exception {
+        String token = "abc";
+
+        when(userService.findUserByEmail(any())).thenReturn(user);
+
+        mockMvc.perform(get("/notDefinedUrl")
+                        .header("Authorization","Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
 }


### PR DESCRIPTION
## :information_desk_person: 간단 소개
spring security 상세 설정입니다.

## :heavy_check_mark: 작업 내용 설명
### 내용
- JwtFilter 작성하였습니다.
- JwtFilter 상단에 JwtExceptionFilter로 JwtFilter에서 예외발생시 JwtExceptionFilter에서 catch 하도록 설정했습니다.
- CustomAuthenticationEntryPoint를 정의하여 인증이 필요하지만 인증되지 못한 경우 예외 발생시키도록 하였습니다.
- CustomAccessDeniedHandler를 정의하여 인증이 되었지만 접근이 제한된 경우(ex. ADMIN만 접근 가능)에 대해 예외 발생시키도록 하였습니다.
- 모든 경우에 대한 테스트 코드 작성하였습니다.

#### 이슈
url 매핑이 되지 않는 경우나 비슷하게 url은 매핑이 되지만 http method가 다른 경우에 대해서 서블릿단에서 해당하는 예외(404 Not Found, 405 Method Not Allowed)를 발생시켜야 하는데 괜히 토큰 때문에 토큰 관련 에러가 발생되는 이슈가 있었습니다.
:arrow_right: **수정하여 filter에서 막히지 않고 서블릿까지 내려가 예외처리되도록 하였습니다(토큰 존재 유무와 상관없이).**

## :bulb: 참고사항
1. `SecurityConfiguration`에서 `authorizeHttpRequests` 부분에서 마지막에 `anyRequest.permitAll()`로 설정해놓았습니다. 그래야 잘못된 url로 접근한 경우 **일단 filter는 통과하고 서블릿에서 예외를 발생시킬 수 있습니다**. **_그래서 결론은, 저 부분은 변경하지 말고 인증이 필요한 url의 경우 authorizeHttpRequests 부분에 추가해주세요._**
2. 일단 accessToken만 들어오는 경우에 대해서 코드 작성했는데 로그인, 로그아웃 코드 병합한 후 로직 추가/변경 하겠습니다.
