### PR TITLE
46 전체적인 dto layer 사용 및 lombok 리펙토링 작업

### DIFF
--- a/src/main/java/com/dev/museummate/controller/ExampleController.java
+++ b/src/main/java/com/dev/museummate/controller/ExampleController.java
@@ -2,18 +2,20 @@ package com.dev.museummate.controller;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/example")
 public class ExampleController {
 
     // 시큐리티 테스트를 위한 임의의 endpoint
-    @GetMapping("/example/security")
+    @GetMapping("/security")
     public String securityTest(Authentication authentication){
         return "security test success";
     }
 
-    @GetMapping("/example/security/admin")
+    @GetMapping("/security/admin")
     public String securityTestAdmin(Authentication authentication){
         return "security test success";
     }

--- a/src/main/java/com/dev/museummate/controller/ExhibitionController.java
+++ b/src/main/java/com/dev/museummate/controller/ExhibitionController.java
@@ -1,6 +1,7 @@
 package com.dev.museummate.controller;
 
 import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.exhibition.BookmarkAddResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.service.ExhibitionService;
 import lombok.RequiredArgsConstructor;
@@ -8,22 +9,26 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/exhibitions")
+@RequestMapping("/api/v1/exhibitions")
 @RequiredArgsConstructor
 public class ExhibitionController {
 
     private final ExhibitionService exhibitionService;
 
     @GetMapping("/{exhibitionId}")
-    public Response getOne(@PathVariable long id) {
-        ExhibitionResponse exhibitionResponse = exhibitionService.getOne(id);
+    public Response getOne(@PathVariable Long exhibitionId) {
+
+        ExhibitionResponse exhibitionResponse = exhibitionService.getOne(exhibitionId);
+
         return Response.success(exhibitionResponse);
     }
 
     @PostMapping("/{exhibitionId}/bookmarks")
-    public Response addToBookmark(@PathVariable long exhibitionId, Authentication authentication) {
-        String result = exhibitionService.addToBookmark(exhibitionId, authentication.getName());
-        return Response.success(result);
+    public Response addToBookmark(@PathVariable Long exhibitionId, Authentication authentication) {
+
+        BookmarkAddResponse bookmarkAddResponse = exhibitionService.addToBookmark(exhibitionId, authentication.getName());
+
+        return Response.success(bookmarkAddResponse);
     }
 
 }

--- a/src/main/java/com/dev/museummate/controller/UserController.java
+++ b/src/main/java/com/dev/museummate/controller/UserController.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/BookmarkAddResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/BookmarkAddResponse.java
@@ -1,0 +1,17 @@
+package com.dev.museummate.domain.dto.exhibition;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkAddResponse {
+
+    private String message;
+    private Long exhibitionId;
+
+    @Builder
+    public BookmarkAddResponse(String message, Long exhibitionId) {
+        this.message = message;
+        this.exhibitionId = exhibitionId;
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/BookmarkDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/BookmarkDto.java
@@ -1,0 +1,37 @@
+package com.dev.museummate.domain.dto.exhibition;
+
+import com.dev.museummate.domain.entity.BookmarkEntity;
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkDto {
+
+    private Long id;
+    private UserEntity user;
+    private ExhibitionEntity exhibition;
+
+    @Builder
+    public BookmarkDto(Long id, UserEntity user, ExhibitionEntity exhibition) {
+        this.id = id;
+        this.user = user;
+        this.exhibition = exhibition;
+    }
+
+    /**
+     * Entity 객체를 Dto 객체로 변환하는 메소드
+     */
+    public static BookmarkDto toDto(BookmarkEntity bookmarkEntity) {
+
+        return BookmarkDto.builder()
+                .id(bookmarkEntity.getId())
+                .user(bookmarkEntity.getUser())
+                .exhibition(bookmarkEntity.getExhibition())
+                .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionDto.java
@@ -1,0 +1,59 @@
+package com.dev.museummate.domain.dto.exhibition;
+
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.GalleryEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitionDto {
+
+    private Long id;
+
+    private String name;
+    private String startsAt;
+    private String endsAt;
+    private String price;
+    private String ageLimit;
+    private String detailInfo;
+    private String galleryDetail;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gallery_id")
+    private GalleryEntity gallery;
+
+    @Builder
+    public ExhibitionDto(Long id, String name, String startsAt, String endsAt, String price, String ageLimit, String detailInfo, String galleryDetail, GalleryEntity gallery) {
+        this.id = id;
+        this.name = name;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+        this.price = price;
+        this.ageLimit = ageLimit;
+        this.detailInfo = detailInfo;
+        this.galleryDetail = galleryDetail;
+        this.gallery = gallery;
+    }
+
+    /**
+     * Entity 객체를 Dto 객체로 변환하는 메소드
+     */
+    public static ExhibitionDto toDto(ExhibitionEntity exhibitionEntity) {
+
+        return ExhibitionDto.builder()
+                .id(exhibitionEntity.getId())
+                .name(exhibitionEntity.getName())
+                .startsAt(exhibitionEntity.getStartsAt())
+                .endsAt(exhibitionEntity.getEndsAt())
+                .price(exhibitionEntity.getPrice())
+                .ageLimit(exhibitionEntity.getAgeLimit())
+                .detailInfo(exhibitionEntity.getDetailInfo())
+                .galleryDetail(exhibitionEntity.getGalleryDetail())
+                .gallery(exhibitionEntity.getGallery())
+                .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
@@ -18,5 +18,5 @@ public class ExhibitionResponse {
     private String ageLimit;
     private String detailInfo;
     private String galleryDetail;
-    private long galleryId;
+    private Long galleryId;
 }

--- a/src/main/java/com/dev/museummate/domain/dto/user/UserDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/user/UserDto.java
@@ -1,12 +1,13 @@
 package com.dev.museummate.domain.dto.user;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import com.dev.museummate.domain.entity.UserEntity;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserDto {
     private Long id;
     private String email;
@@ -27,6 +28,9 @@ public class UserDto {
         this.address = address;
     }
 
+    /**
+     * UserEntity를 UserDto로 변환
+     */
     public static UserDto toDto(UserEntity savedUser) {
 
         return UserDto.builder()

--- a/src/main/java/com/dev/museummate/domain/dto/user/UserJoinRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/user/UserJoinRequest.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserJoinRequest {
     private String email;
     private String password;

--- a/src/main/java/com/dev/museummate/domain/dto/user/UserLoginRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/user/UserLoginRequest.java
@@ -2,9 +2,11 @@ package com.dev.museummate.domain.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserLoginRequest {
     private String email;
     private String password;

--- a/src/main/java/com/dev/museummate/domain/dto/user/UserLoginResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/user/UserLoginResponse.java
@@ -2,9 +2,11 @@ package com.dev.museummate.domain.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserLoginResponse {
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/dev/museummate/domain/dto/user/UserReissueRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/user/UserReissueRequest.java
@@ -2,8 +2,10 @@ package com.dev.museummate.domain.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserReissueRequest {
     private String accessToken;

--- a/src/main/java/com/dev/museummate/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/BookmarkEntity.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Table(name = "bookmark")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookmarkEntity {
 

--- a/src/main/java/com/dev/museummate/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/BookmarkEntity.java
@@ -1,21 +1,16 @@
 package com.dev.museummate.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookmarkEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -25,13 +20,19 @@ public class BookmarkEntity {
     @JoinColumn(name = "exhibition_id")
     private ExhibitionEntity exhibition;
 
-    public static BookmarkEntity of(ExhibitionEntity exhibition, UserEntity user) {
-        BookmarkEntity bookmark = BookmarkEntity.builder()
+    @Builder
+    public BookmarkEntity(long id, UserEntity user, ExhibitionEntity exhibition) {
+        this.id = id;
+        this.user = user;
+        this.exhibition = exhibition;
+    }
+
+    public static BookmarkEntity CreateBookmark(ExhibitionEntity exhibition, UserEntity user) {
+
+        return BookmarkEntity.builder()
                 .exhibition(exhibition)
                 .user(user)
                 .build();
-
-        return bookmark;
     }
 
 }

--- a/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
@@ -2,21 +2,16 @@ package com.dev.museummate.domain.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitionEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     private String name;
     private String startsAt;
@@ -30,4 +25,16 @@ public class ExhibitionEntity {
     @JoinColumn(name = "gallery_id")
     private GalleryEntity gallery;
 
+    @Builder
+    public ExhibitionEntity(long id, String name, String startsAt, String endsAt, String price, String ageLimit, String detailInfo, String galleryDetail, GalleryEntity gallery) {
+        this.id = id;
+        this.name = name;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+        this.price = price;
+        this.ageLimit = ageLimit;
+        this.detailInfo = detailInfo;
+        this.galleryDetail = galleryDetail;
+        this.gallery = gallery;
+    }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Table(name = "exhibition")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitionEntity {
 

--- a/src/main/java/com/dev/museummate/domain/entity/GalleryEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/GalleryEntity.java
@@ -4,25 +4,28 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GalleryEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     private String name;
     private String address;
     private String openTime;
     private String closeTime;
 
+    @Builder
+    public GalleryEntity(long id, String name, String address, String openTime, String closeTime) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/GalleryEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/GalleryEntity.java
@@ -1,13 +1,11 @@
 package com.dev.museummate.domain.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
 @Getter
+@Table(name = "gallery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GalleryEntity {
 

--- a/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
@@ -19,7 +19,7 @@ public class UserEntity extends BaseEntity{
      * userName : 유저 실명
      */
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String email;
     private String password;

--- a/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
@@ -12,6 +12,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity extends BaseEntity{
+
+    /**
+     * id : idx
+     * email : 유저 이메일
+     * userName : 유저 실명
+     */
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -32,10 +32,10 @@ public class SecurityConfiguration {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/users/join","/users/login").permitAll()
+                        .requestMatchers("/api/v1/users/join","/api/v1/users/login").permitAll()
                         .requestMatchers(HttpMethod.GET,"/example/security").authenticated()
                         .requestMatchers(HttpMethod.GET, "/example/security/admin").hasRole("ADMIN")
-                        .requestMatchers("/users/reissue","/users/logout").authenticated()
+                        .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout").authenticated()
                         .anyRequest().permitAll()   //고정
                 )
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dev/museummate/service/ExhibitionService.java
+++ b/src/main/java/com/dev/museummate/service/ExhibitionService.java
@@ -1,5 +1,8 @@
 package com.dev.museummate.service;
 
+import com.dev.museummate.domain.dto.exhibition.BookmarkAddResponse;
+import com.dev.museummate.domain.dto.exhibition.BookmarkDto;
+import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.domain.entity.BookmarkEntity;
 import com.dev.museummate.domain.entity.ExhibitionEntity;
@@ -26,35 +29,55 @@ public class ExhibitionService {
     // 전시 상세 조회
     public ExhibitionResponse getOne(long exhibitionId) {
         ExhibitionEntity selectedExhibition = exhibitionRepository.findById(exhibitionId)
-                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_POST, "존재하지 않는 게시물입니다."));
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_POST, "존재하지 않는 전시회입니다."));
+
+        ExhibitionDto selectedExhibitionDto = ExhibitionDto.toDto(selectedExhibition);
 
         return new ExhibitionResponse(
-                selectedExhibition.getName(),
-                selectedExhibition.getStartsAt(),
-                selectedExhibition.getEndsAt(),
-                selectedExhibition.getPrice(),
-                selectedExhibition.getAgeLimit(),
-                selectedExhibition.getDetailInfo(),
-                selectedExhibition.getGalleryDetail(),
-                selectedExhibition.getGallery().getId()
+                selectedExhibitionDto.getName(),
+                selectedExhibitionDto.getStartsAt(),
+                selectedExhibitionDto.getEndsAt(),
+                selectedExhibitionDto.getPrice(),
+                selectedExhibitionDto.getAgeLimit(),
+                selectedExhibitionDto.getDetailInfo(),
+                selectedExhibitionDto.getGalleryDetail(),
+                selectedExhibitionDto.getGallery().getId()
         );
     }
 
     // 해당하는 exhibition을 Bookmark에 추가
-    public String addToBookmark(long exhibitionId, String userName) {
-        UserEntity user = userRepository.findByUserName(userName)
-                .orElseThrow(() -> new AppException(ErrorCode.USERNAME_NOT_FOUND, "존재하지 않는 유저입니다."));
+    public BookmarkAddResponse addToBookmark(long exhibitionId, String email) {
+
+        // 유저 네임 검증
+        // TODO: 22.01.21 userName -> email로 변경
+        UserEntity user = userRepository.findByUserName(email)
+                .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND, "존재하지 않는 유저입니다."));
+
+        // 전시회 검증
         ExhibitionEntity selectedExhibition = exhibitionRepository.findById(exhibitionId)
-                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_POST, "존재하지 않는 게시물입니다."));
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_POST, "존재하지 않는 전시회입니다."));
+
         Optional<BookmarkEntity> selected = bookmarkRepository.findByExhibitionAndUser(selectedExhibition, user);
 
         if(!selected.isPresent()) {
-            BookmarkEntity bookmark = BookmarkEntity.of(selectedExhibition, user);
+
+            // Bookmark Entity 생성
+            BookmarkEntity bookmark = BookmarkEntity.CreateBookmark(selectedExhibition, user);
+
+            // Bookmark Entity 저장
             bookmarkRepository.save(bookmark);
-            return "북마크에 추가되었습니다!";
+
+            return BookmarkAddResponse.builder()
+                    .message("북마크에 추가되었습니다.")
+                    .exhibitionId(exhibitionId)
+                    .build();
         }else {
             bookmarkRepository.delete(selected.get());
-            return "북마크에서 삭제되었습니다!";
+
+            return BookmarkAddResponse.builder()
+                    .message("북마크에서 삭제되었습니다.")
+                    .exhibitionId(exhibitionId)
+                    .build();
         }
     }
 

--- a/src/main/java/com/dev/museummate/service/UserService.java
+++ b/src/main/java/com/dev/museummate/service/UserService.java
@@ -31,13 +31,6 @@ public class UserService {
     private static final long accessExpireTimeMs = 1000 * 60 * 5;
     private static final long refreshExpireTimeMs = 1000 * 60 * 30;
 
-
-
-    public UserEntity findUserByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow(() ->
-                new AppException(ErrorCode.EMAIL_NOT_FOUND, String.format("%s님은 존재하지 않습니다.",email)));
-    }
-
     public UserEntity findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() ->
                 new AppException(ErrorCode.EMAIL_NOT_FOUND, String.format("%s님은 존재하지 않습니다.",email)));


### PR DESCRIPTION
## :information_desk_person: 간단 소개

Dto 클래스 도입에 따른 전체적인 리펙토링을 진행했습니다.

## :heavy_check_mark: 작업 내용 설명

- Entity Class에서 직접적으로 Response에 전달했던 기존의 코드를 Dto클래스를 거쳐서 Response하도록 변경했습니다.
- 위 작업에 따른 테스트코드 추가 및 변경이 있습니다.
- 모든 API Endpoint를 `api/v1`으로 시작하게 변경하였습니다.
- 코드 가독성을 위해 Entity Class 명을 Entity를 지정했으므로, DB Table Name에서는 Entity Naming제거를 위해서 Table Name을 지정해주었습니다.

## :bulb: 참고사항
로직 변경 등 리뷰어나 다른 팀원들이 참고해야 할 사항을 적어주세요.

이슈에 참고 및 논의 나눠야할 내용을 적어두었습니다.
한 번 확인 부탁드립니다!