### PR TITLE
47 swagger 추가 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,19 +19,41 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // Javax
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.4'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Lombok for TestCode
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // Swagger (springdoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dev/museummate/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/dev/museummate/configuration/SwaggerConfiguration.java
@@ -1,0 +1,33 @@
+package com.dev.museummate.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * Swagger springdoc-ui 설정
+ */
+@OpenAPIDefinition(
+        info = @Info(
+                title = "MuseumMate API 명세서",
+                description = "MuseumMate API",
+                version = "1.0.0"
+        )
+)
+@Configuration
+public class SwaggerConfiguration {
+
+    @Bean
+    public GroupedOpenApi museummateOpenApi() {
+
+        String paths[] = {"/api/**"};
+
+        return GroupedOpenApi.builder()
+                .group("MuseumMate OpenAPI 1.0.0")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,22 @@ spring:
 jwt:
   secret: example
 
+# Swagger (springdoc-openapi-ui)
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true                   # 기본경로 해제
+    path: /swagger-ui.html                              # swagger-ui.html을 기본 경로로 설정
+    groups-order: DESC                                  # Swagger Grouping 정렬
+    operations-sorter: method                           # method, alpha
+    display-request-duration: true                      # 요청 시간 표시
+
+  api-docs:
+    path: /api-docs                                     # API 문서 경로 (Json 형태)
+  paths-to-match: /api/**                               # Swagger 문서에 표시할 경로
+  show-actuator: true                                   # Actuator API 문서 표시
+  default-produces-media-type: application/json         # 기본 응답 타입
+  default-consumes-media-type: application/json         # 기본 요청 타입
+
 
 
 #########################################################


### PR DESCRIPTION
## :information_desk_person: 간단 소개

API 문서 자동화를 위한 Swagger 추가 PR입니다.

## :heavy_check_mark: 작업 내용 설명

- `build.gradle`를 좀 더 보기 편하게 주석을 추가하였습니다
- `Lombok`을 TestCode 에서도 이용할 수 있게 관련 의존성을 추가하였습니다.
- Swaggerdoc 의 의존성을 추가하였습니다.
- API 문서 자동화를 위한 Swagger을 추가하였습니다.

## :bulb: 참고사항
로직 변경 등 리뷰어나 다른 팀원들이 참고해야 할 사항을 적어주세요.

> 현재 Spring boot 3 버전이상에서 `Springfox`를 이용해서 `Swagger`를 적용하려하니 적용이 되지않았습니다.
`Springfox` 공식 Github에서 이슈들을 보니 `Springdoc`을 이용하라는 글이 많이 보였습니다.
또한 `Springfox` 프로젝트가 한동안 진행되고 있지 않다는 글을 보게되어서
`Springdoc`을 사용해서 Swagger를 추가하였습니다.