### PR TITLE
fix: 북마크 추가 성공/실패 테스트케이스 수정

### DIFF
--- a/src/main/java/com/dev/museummate/controller/ExhibitionController.java
+++ b/src/main/java/com/dev/museummate/controller/ExhibitionController.java
@@ -1,6 +1,7 @@
 package com.dev.museummate.controller;
 
 import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.bookmark.BookmarkResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.service.ExhibitionService;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +23,8 @@ public class ExhibitionController {
 
     @PostMapping("/{exhibitionId}/bookmark")
     public Response addToBookmark(@PathVariable long exhibitionId, Authentication authentication) {
-        String result = exhibitionService.addToBookmark(exhibitionId, authentication.getName());
-        return Response.success(result);
+        BookmarkResponse bookmarkResponse = exhibitionService.addToBookmark(exhibitionId, authentication.getName());
+        return Response.success(bookmarkResponse);
     }
 
 }

--- a/src/main/java/com/dev/museummate/domain/dto/bookmark/BookmarkResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/bookmark/BookmarkResponse.java
@@ -1,0 +1,10 @@
+package com.dev.museummate.domain.dto.bookmark;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BookmarkResponse {
+    private String message;
+}

--- a/src/main/java/com/dev/museummate/service/ExhibitionService.java
+++ b/src/main/java/com/dev/museummate/service/ExhibitionService.java
@@ -42,9 +42,9 @@ public class ExhibitionService {
     }
 
     // 해당하는 exhibition을 Bookmark에 추가
-    public BookmarkResponse addToBookmark(long exhibitionId, String userName) {
-        UserEntity user = userRepository.findByUserName(userName)
-                .orElseThrow(() -> new AppException(ErrorCode.USERNAME_NOT_FOUND, "존재하지 않는 유저입니다."));
+    public BookmarkResponse addToBookmark(long exhibitionId, String email) {
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND, "존재하지 않는 유저입니다."));
         ExhibitionEntity selectedExhibition = exhibitionRepository.findById(exhibitionId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_POST, "존재하지 않는 게시물입니다."));
         Optional<BookmarkEntity> selected = bookmarkRepository.findByExhibitionAndUser(selectedExhibition, user);

--- a/src/main/java/com/dev/museummate/service/ExhibitionService.java
+++ b/src/main/java/com/dev/museummate/service/ExhibitionService.java
@@ -1,5 +1,6 @@
 package com.dev.museummate.service;
 
+import com.dev.museummate.domain.dto.bookmark.BookmarkResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.domain.entity.BookmarkEntity;
 import com.dev.museummate.domain.entity.ExhibitionEntity;
@@ -41,7 +42,7 @@ public class ExhibitionService {
     }
 
     // 해당하는 exhibition을 Bookmark에 추가
-    public String addToBookmark(long exhibitionId, String userName) {
+    public BookmarkResponse addToBookmark(long exhibitionId, String userName) {
         UserEntity user = userRepository.findByUserName(userName)
                 .orElseThrow(() -> new AppException(ErrorCode.USERNAME_NOT_FOUND, "존재하지 않는 유저입니다."));
         ExhibitionEntity selectedExhibition = exhibitionRepository.findById(exhibitionId)
@@ -51,10 +52,10 @@ public class ExhibitionService {
         if(!selected.isPresent()) {
             BookmarkEntity bookmark = BookmarkEntity.of(selectedExhibition, user);
             bookmarkRepository.save(bookmark);
-            return "북마크에 추가되었습니다!";
+            return new BookmarkResponse("북마크에 추가되었습니다!");
         }else {
             bookmarkRepository.delete(selected.get());
-            return "북마크에서 삭제되었습니다!";
+            return new BookmarkResponse("북마크에서 삭제되었습니다!");
         }
     }
 


### PR DESCRIPTION
## :information_desk_person: 간단 소개
북마크 추가 성공/실패 테스트코드 수정

## :heavy_check_mark: 작업 내용 설명
북마크 추가 성공/실패 테스트코드 test passed 되게끔 수정했습니다.

## :bulb: 참고사항
"전시 상세 조회 성공" 케이스는 그대로 두었습니다!
