### PR TITLE
63 유저탈퇴 기능

### DIFF
--- a/src/main/java/com/dev/museummate/controller/UserController.java
+++ b/src/main/java/com/dev/museummate/controller/UserController.java
@@ -49,5 +49,12 @@ public class UserController {
         return Response.success(msg);
     }
 
+    @DeleteMapping("/delete")
+    public Response<String> delete(Authentication authentication) {
+        String msg = userService.deleteUser(authentication.getName());
+        return Response.success(msg);
+    }
+
+
 
 }

--- a/src/main/java/com/dev/museummate/domain/entity/BaseTimeEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/BaseTimeEntity.java
@@ -21,4 +21,6 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     @Column
     private LocalDateTime lastModifiedAt;
+
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/UserEntity.java
@@ -7,11 +7,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = current_timestamp where id = ?")
+@Where(clause = "deleted_at is NULL")
+
 public class UserEntity extends BaseEntity{
 
     /**

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -37,7 +37,7 @@ public class SecurityConfiguration {
                         .requestMatchers("/api/v1/users/join","/api/v1/users/login","/api/v1/users/check").permitAll()
                         .requestMatchers(HttpMethod.GET,"/example/security").authenticated()
                         .requestMatchers(HttpMethod.GET, "/example/security/admin").hasRole("ADMIN")
-                        .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout","/api/v1/users/modify").authenticated()
+                        .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout","/api/v1/users/modify","/api/v1/users/delete").authenticated()
                         .anyRequest().permitAll()   //고정
                 )
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dev/museummate/service/UserService.java
+++ b/src/main/java/com/dev/museummate/service/UserService.java
@@ -11,6 +11,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
@@ -26,7 +27,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder encoder;
     private final RedisDao redisDao;
-    private final RedisTemplate redisTemplate;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -142,5 +142,14 @@ public class UserService {
         userRepository.save(findUser);
 
         return "수정이 완료 되었습니다.";
+    }
+
+    public String deleteUser(String email) {
+
+        UserEntity findUser = findUserByEmail(email);
+
+        userRepository.delete(findUser);
+
+        return "탈퇴가 완료 되었습니다.";
     }
 }

--- a/src/test/java/com/dev/museummate/controller/UserControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/UserControllerTest.java
@@ -21,8 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -420,6 +419,34 @@ class UserControllerTest {
                 .andExpect(status().isNotFound());
 
         //then
+    }
+
+    @Test
+    @DisplayName("유저 삭제 - 성공")
+    @WithMockUser
+    void user_delete_success() throws Exception {
+        //given
+        given(userService.deleteUser(any()))
+                .willReturn("삭제가 완료 되었습니다.");
+        //when
+        mockMvc.perform(delete("/api/v1/users/delete")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유저 삭제 - 실패#1 - 유저 찾을 수 없음")
+    @WithMockUser
+    void user_delete_fail() throws Exception {
+        //given
+        given(userService.deleteUser(any()))
+                .willThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND,""));
+        //when
+        mockMvc.perform(delete("/api/v1/users/delete")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isNotFound());
     }
 
 


### PR DESCRIPTION
## :information_desk_person: 간단 소개
유저 삭제 기능 입니다

## :heavy_check_mark: 작업 내용 설명
BaseTimeEntity - deletedAt 추가
security - "/api/v1/users/delete" 권한 추가
controller - delete mapping api 추가
service - 이메일로 유저 조회 후 delete
entity - delete 쿼리 발생시 update 쿼리 실행, where로 delete_at null 만 조회

## :bulb: 참고사항
redis DI필요없는게 있어서 삭제했습니다