### PR TITLE
전시 알람 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Mail
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dev/museummate/configuration/SchedulerConfiguration.java
+++ b/src/main/java/com/dev/museummate/configuration/SchedulerConfiguration.java
@@ -1,0 +1,9 @@
+package com.dev.museummate.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfiguration {
+}

--- a/src/main/java/com/dev/museummate/controller/MyController.java
+++ b/src/main/java/com/dev/museummate/controller/MyController.java
@@ -1,10 +1,16 @@
 package com.dev.museummate.controller;
 
 import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.alarm.AlarmDto;
+import com.dev.museummate.domain.dto.alarm.AlarmResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.service.MyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +30,16 @@ public class MyController {
         List<ExhibitionDto> exhibitionDtos = myService.getMyCalendar(authentication.getName());
         return Response.success(exhibitionDtos.stream().map(exhibition ->
                 ExhibitionResponse.of(exhibition)));
+    }
+
+    @GetMapping("/alarms")
+    public Response getAlarms(@PageableDefault(size = 20, sort = "name", direction = Sort.Direction.DESC) Pageable pageable, Authentication authentication){
+        Page<AlarmDto> alarmDtos = myService.getAlarms(pageable, authentication.getName());
+
+        Page<AlarmResponse> alarmResponses = alarmDtos.map(alarmDto -> AlarmResponse.builder()
+                .userName(alarmDto.getUser().getUserName())
+                .exhibitionName(alarmDto.getExhibition().getName())
+                .alarmMessage(alarmDto.getAlarmMessage()).build());
+        return Response.success(alarmResponses);
     }
 }

--- a/src/main/java/com/dev/museummate/domain/AlarmType.java
+++ b/src/main/java/com/dev/museummate/domain/AlarmType.java
@@ -1,0 +1,16 @@
+package com.dev.museummate.domain;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum AlarmType {
+    WEEK_BEFORE_END(7,"전시 종료 7일 전입니다."),
+    DAY_BEFORE_END(1, "전시 종료 1일 전입니다.")
+    ;
+    private Integer leftDate;
+    private String alarmMessage;
+}

--- a/src/main/java/com/dev/museummate/domain/dto/alarm/AlarmDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/alarm/AlarmDto.java
@@ -1,0 +1,35 @@
+package com.dev.museummate.domain.dto.alarm;
+
+import com.dev.museummate.domain.entity.AlarmEntity;
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlarmDto {
+    private Long id;
+    private UserEntity user;
+    private ExhibitionEntity exhibition;
+    private String alarmMessage;
+
+    @Builder
+    public AlarmDto(Long id, UserEntity user, ExhibitionEntity exhibition, String alarmMessage) {
+        this.id = id;
+        this.user = user;
+        this.exhibition = exhibition;
+        this.alarmMessage = alarmMessage;
+    }
+
+    public static AlarmDto toDto(AlarmEntity alarm) {
+        return AlarmDto.builder()
+                .id(alarm.getId())
+                .user(alarm.getUser())
+                .exhibition(alarm.getExhibition())
+                .alarmMessage(alarm.getAlarmMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/alarm/AlarmResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/alarm/AlarmResponse.java
@@ -1,0 +1,21 @@
+package com.dev.museummate.domain.dto.alarm;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlarmResponse {
+    private String userName;
+    private String exhibitionName;
+    private String alarmMessage;
+
+    @Builder
+    public AlarmResponse(String userName, String exhibitionName, String alarmMessage) {
+        this.userName = userName;
+        this.exhibitionName = exhibitionName;
+        this.alarmMessage = alarmMessage;
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/entity/AlarmEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/AlarmEntity.java
@@ -3,6 +3,7 @@ package com.dev.museummate.domain.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,5 +29,19 @@ public class AlarmEntity extends BaseTimeEntity{
     @NotNull
     private ExhibitionEntity exhibition;
 
+    @Builder
+    public AlarmEntity(Long id, String alarmMessage, UserEntity user, ExhibitionEntity exhibition) {
+        this.id = id;
+        this.alarmMessage = alarmMessage;
+        this.user = user;
+        this.exhibition = exhibition;
+    }
 
+    public static AlarmEntity createAlarm(UserEntity user, ExhibitionEntity exhibition, String alarmMessage){
+        return AlarmEntity.builder()
+                .user(user)
+                .exhibition(exhibition)
+                .alarmMessage(alarmMessage)
+                .build();
+    }
 }

--- a/src/main/java/com/dev/museummate/repository/AlarmRepository.java
+++ b/src/main/java/com/dev/museummate/repository/AlarmRepository.java
@@ -1,0 +1,11 @@
+package com.dev.museummate.repository;
+
+import com.dev.museummate.domain.entity.AlarmEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<AlarmEntity, Long> {
+    Page<AlarmEntity> findByUser(Pageable pageable, UserEntity user);
+}

--- a/src/main/java/com/dev/museummate/repository/BookmarkRepository.java
+++ b/src/main/java/com/dev/museummate/repository/BookmarkRepository.java
@@ -16,4 +16,6 @@ public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> 
     Optional<BookmarkEntity> findByExhibitionAndUser(ExhibitionEntity exhibition, UserEntity user);
 
     List<BookmarkEntity> findByUser(UserEntity user);
+
+    List<BookmarkEntity> findByExhibition_EndsAt(String date);
 }

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET,"/api/v1/example/security").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/example/security/admin").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout","/api/v1/users/modify","/api/v1/users/delete").authenticated()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/my/calendars").authenticated()
+                        .requestMatchers(HttpMethod.GET,"/api/v1/my/**").authenticated()
                         .anyRequest().permitAll()   //고정
                 )
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dev/museummate/service/AlarmScheduler.java
+++ b/src/main/java/com/dev/museummate/service/AlarmScheduler.java
@@ -1,0 +1,49 @@
+package com.dev.museummate.service;
+
+import com.dev.museummate.domain.AlarmType;
+import com.dev.museummate.domain.entity.AlarmEntity;
+import com.dev.museummate.domain.entity.BookmarkEntity;
+import com.dev.museummate.repository.AlarmRepository;
+import com.dev.museummate.repository.BookmarkRepository;
+import com.dev.museummate.utils.MailUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmScheduler {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final AlarmRepository alarmRepository;
+
+    @Scheduled(cron = "0 50 8 * * *")
+    @Transactional
+    public void makeAlarms(){
+
+        //북마크 돌면서 1일전꺼 알람 발생
+        bookmarkAlarms(AlarmType.DAY_BEFORE_END);
+
+        //북마크 돌면서 7일전꺼 알람 발생
+        bookmarkAlarms(AlarmType.WEEK_BEFORE_END);
+    }
+
+    private void bookmarkAlarms(AlarmType alarmType) {
+        String date = LocalDateTime.now().plusDays(alarmType.getLeftDate()).format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        List<BookmarkEntity> bookmarkEntityList = bookmarkRepository.findByExhibition_EndsAt(date);
+
+        for (BookmarkEntity bookmark: bookmarkEntityList) {
+
+            AlarmEntity alarm = AlarmEntity.createAlarm(bookmark.getUser(), bookmark.getExhibition(), alarmType.getAlarmMessage());
+            alarmRepository.save(alarm);
+
+            MailUtils.bookmarkMailSend(bookmark.getUser().getAddress(), bookmark.getUser().getUserName(), bookmark.getExhibition().getName(), alarmType.getLeftDate());
+        }
+    }
+}
+

--- a/src/main/java/com/dev/museummate/service/MyService.java
+++ b/src/main/java/com/dev/museummate/service/MyService.java
@@ -1,15 +1,20 @@
 package com.dev.museummate.service;
 
+import com.dev.museummate.domain.dto.alarm.AlarmDto;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
+import com.dev.museummate.domain.entity.AlarmEntity;
 import com.dev.museummate.domain.entity.BookmarkEntity;
 import com.dev.museummate.domain.entity.ExhibitionEntity;
 import com.dev.museummate.domain.entity.UserEntity;
 import com.dev.museummate.exception.AppException;
 import com.dev.museummate.exception.ErrorCode;
+import com.dev.museummate.repository.AlarmRepository;
 import com.dev.museummate.repository.BookmarkRepository;
 import com.dev.museummate.repository.ExhibitionRepository;
 import com.dev.museummate.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +27,7 @@ public class MyService {
 
     private final UserRepository userRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final AlarmRepository alarmRepository;
 
     public UserEntity findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() ->
@@ -37,5 +43,12 @@ public class MyService {
 
         List<ExhibitionDto> exhibitionDtos =  exhibitionEntities.stream().map(exhibition -> ExhibitionDto.toDto(exhibition)).collect(Collectors.toList());
         return exhibitionDtos;
+    }
+
+    public Page<AlarmDto> getAlarms(Pageable pageable, String email) {
+        UserEntity user = findUserByEmail(email);
+
+        Page<AlarmEntity> alarmEntities = alarmRepository.findByUser(pageable, user);
+        return alarmEntities.map(alarm -> AlarmDto.toDto(alarm));
     }
 }

--- a/src/main/java/com/dev/museummate/utils/MailUtils.java
+++ b/src/main/java/com/dev/museummate/utils/MailUtils.java
@@ -1,0 +1,71 @@
+package com.dev.museummate.utils;
+
+import jakarta.mail.*;
+import jakarta.mail.internet.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Properties;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MailUtils {
+
+    private static String id; // gmail 계정
+
+    private static String password;   // gmail 패스워드
+
+    @Value("${mail.sender.id}")
+    public void setId(String id){
+        this.id = id;
+    }
+
+    @Value("${mail.sender.password}")
+    public void setPassword(String password){
+        this.password = password;
+    }
+
+    public static MimeMessage mailConfiguration() {
+
+        Properties prop = new Properties();
+        prop.put("mail.smtp.host", "smtp.gmail.com");
+        prop.put("mail.smtp.port", 465);
+        prop.put("mail.smtp.auth", "true");
+        prop.put("mail.smtp.ssl.enable", "true");
+        prop.put("mail.smtp.ssl.trust", "smtp.gmail.com");
+
+        Session session = Session.getDefaultInstance(prop, new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(id, password);
+            }
+        });
+
+        return new MimeMessage(session);
+
+    }
+
+    public static void bookmarkMailSend(String toEmailAddress, String userName, String exhibitionName, Integer leftDate){
+
+        try{
+            MimeMessage message = mailConfiguration();
+            message.setFrom(new InternetAddress(id));
+
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(toEmailAddress));
+
+            message.setSubject(String.format("[Museum Mate]: 전시 일정 안내")); //메일 제목을 입력
+
+            message.setText(String.format("%s님께서 북마크한 전시 [%s] 마감 %d일 전입니다!", userName, exhibitionName, leftDate));    //메일 내용을 입력
+
+            Transport.send(message);
+            log.info("mail 전송 완료");
+
+        } catch (AddressException e) {
+            e.printStackTrace();
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/dev/museummate/controller/MyControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/MyControllerTest.java
@@ -1,7 +1,10 @@
 package com.dev.museummate.controller;
 
+import com.dev.museummate.domain.dto.alarm.AlarmDto;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
+import com.dev.museummate.domain.entity.ExhibitionEntity;
 import com.dev.museummate.domain.entity.GalleryEntity;
+import com.dev.museummate.domain.entity.UserEntity;
 import com.dev.museummate.exception.AppException;
 import com.dev.museummate.exception.ErrorCode;
 import com.dev.museummate.service.ExhibitionService;
@@ -13,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -36,6 +41,8 @@ public class MyControllerTest {
     MyService myService;
 
     private ExhibitionDto exhibitionDto;
+    private AlarmDto alarmDto;
+
 
     @BeforeEach
     void setUp(){
@@ -50,6 +57,11 @@ public class MyControllerTest {
                 .galleryDetail("test")
                 .gallery(new GalleryEntity(1l,"test","test","test","test")).build();
 
+        alarmDto = AlarmDto.builder()
+                .user(UserEntity.builder().userName("test").build())
+                .exhibition(ExhibitionEntity.builder().name("test").build())
+                .alarmMessage("")
+                .build();
     }
     @Test
     @DisplayName("마이 캘린더 조회 성공")
@@ -75,6 +87,34 @@ public class MyControllerTest {
         when(myService.getMyCalendar(any())).thenThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND,""));
 
         mockMvc.perform(get("/api/v1/my/calendars"))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("알람 조회 성공")
+    @WithMockUser
+    void getAlarmsSuccess() throws Exception {
+
+        Page<AlarmDto> dtoPage = new PageImpl<>(List.of(alarmDto));
+
+        when(myService.getAlarms(any(), any())).thenReturn(dtoPage);
+
+        mockMvc.perform(get("/api/v1/my/alarms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content").exists())
+                .andExpect(jsonPath("$.result.pageable").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("알람 조회 실패 - 유저가 존재하지 않는 경우")
+    @WithMockUser
+    void getAlarmsFail() throws Exception {
+
+        when(myService.getAlarms(any(), any())).thenThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND,""));
+
+        mockMvc.perform(get("/api/v1/my/alarms"))
                 .andExpect(status().isNotFound())
                 .andDo(print());
     }


### PR DESCRIPTION
## :information_desk_person: 간단 소개
전시 알람 기능 서비스

## :heavy_check_mark: 작업 내용 설명
- 알람 발생 기능: 스프링 스케줄러를 사용하여 매일 아침 8시 50분 북마크한 전시에 대해 종료 1일전, 7일전인 전시에 대해서 알람을 발생시키고(알람 리포지터리에 저장), 유저에게 메일을 보냅니다.

- 알람 조회 기능: /api/v1/my/alarms url에 접근 시 나에게 온 알람을 조회할 수 있습니다.

## :bulb: 참고사항
environment variable에 MAIL_SENDER_ID = 이메일, MAIL_SENDER_PASSWORD = 비밀번호를 입력해야 합니다.