### PR TITLE
Bug: of 메소드 매개변수 수정

### DIFF
--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
@@ -57,7 +57,7 @@ public class ExhibitionResponse {
                 .build());
     }
 
-    public static ExhibitionResponse of(ExhibitionEntity exhibition) {
+    public static ExhibitionResponse of(ExhibitionDto exhibition) {
         return ExhibitionResponse.builder()
                 .id(exhibition.getId())
                 .name(exhibition.getName())


### PR DESCRIPTION
## :information_desk_person: 간단 소개
develop 브랜치 컴파일 에러에 따른 수정사항

## :heavy_check_mark: 작업 내용 설명
이전 마이캘린더 기능 구현시 ExhibitionResponse의 of 메소드(ExhibitionResponse 객체 반환하는)의 매개변수를 ExhibitionEntity에서 ExhibitionDto로 수정했는데 반영이 안되거나 다시 덮어졌던 것 같습니다!

## :bulb: 참고사항
X
