### PR TITLE
85 전시회 수정 기능 api 구현

### DIFF
--- a/src/main/java/com/dev/museummate/controller/ExhibitionController.java
+++ b/src/main/java/com/dev/museummate/controller/ExhibitionController.java
@@ -3,9 +3,11 @@ package com.dev.museummate.controller;
 import com.dev.museummate.configuration.Response;
 import com.dev.museummate.domain.dto.exhibition.BookmarkAddResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
+import com.dev.museummate.domain.dto.exhibition.ExhibitionEditRequest;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionWriteRequest;
 import com.dev.museummate.service.ExhibitionService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,32 +29,32 @@ public class ExhibitionController {
         ExhibitionDto exhibitionDto = exhibitionService.getOne(exhibitionId);
 
         return Response.success(ExhibitionResponse.builder()
-                .id(exhibitionDto.getId())
-                .name(exhibitionDto.getName())
-                .startsAt(exhibitionDto.getStartsAt())
-                .endsAt(exhibitionDto.getEndsAt())
-                .price(exhibitionDto.getPrice())
-                .ageLimit(exhibitionDto.getAgeLimit())
-                .detailInfo(exhibitionDto.getDetailInfo())
-                .galleryLocation(exhibitionDto.getGalleryLocation())
-                .galleryId(exhibitionDto.getGallery().getId())
-                .statMale(exhibitionDto.getStatMale())
-                .statFemale(exhibitionDto.getStatFemale())
-                .statAge10(exhibitionDto.getStatAge10())
-                .statAge20(exhibitionDto.getStatAge20())
-                .statAge30(exhibitionDto.getStatAge30())
-                .statAge40(exhibitionDto.getStatAge40())
-                .statAge50(exhibitionDto.getStatAge50())
-                .mainImgUrl(exhibitionDto.getMainImgUrl())
-                .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
-                .detailImgUrl(exhibitionDto.getDetailImgUrl())
-                .build());
+            .id(exhibitionDto.getId())
+            .name(exhibitionDto.getName())
+            .startsAt(exhibitionDto.getStartsAt())
+            .endsAt(exhibitionDto.getEndsAt())
+            .price(exhibitionDto.getPrice())
+            .ageLimit(exhibitionDto.getAgeLimit())
+            .detailInfo(exhibitionDto.getDetailInfo())
+            .galleryLocation(exhibitionDto.getGalleryLocation())
+            .galleryId(exhibitionDto.getGallery().getId())
+            .statMale(exhibitionDto.getStatMale())
+            .statFemale(exhibitionDto.getStatFemale())
+            .statAge10(exhibitionDto.getStatAge10())
+            .statAge20(exhibitionDto.getStatAge20())
+            .statAge30(exhibitionDto.getStatAge30())
+            .statAge40(exhibitionDto.getStatAge40())
+            .statAge50(exhibitionDto.getStatAge50())
+            .mainImgUrl(exhibitionDto.getMainImgUrl())
+            .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
+            .detailImgUrl(exhibitionDto.getDetailImgUrl())
+            .build());
     }
-    
+
     // 전시회 전체 조회
     @GetMapping
-    public Response<Page<ExhibitionResponse>> findAllExhibitions (@PageableDefault(size = 20,
-            sort = "name", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<ExhibitionResponse>> findAllExhibitions(@PageableDefault(size = 20,
+        sort = "name", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<ExhibitionDto> exhibitionDtos = exhibitionService.findAllExhibitions(pageable);
         return Response.success(ExhibitionResponse.of(exhibitionDtos));
     }
@@ -64,26 +66,26 @@ public class ExhibitionController {
         ExhibitionDto exhibitionDto = exhibitionService.write(exhibitionWriteRequest, authentication.getName());
 
         return Response.success(ExhibitionResponse.builder()
-                .id(exhibitionDto.getId())
-                .name(exhibitionDto.getName())
-                .startsAt(exhibitionDto.getStartsAt())
-                .endsAt(exhibitionDto.getEndsAt())
-                .price(exhibitionDto.getPrice())
-                .ageLimit(exhibitionDto.getAgeLimit())
-                .detailInfo(exhibitionDto.getDetailInfo())
-                .galleryLocation(exhibitionDto.getGalleryLocation())
-                .galleryId(exhibitionDto.getGallery().getId())
-                .statMale(exhibitionDto.getStatMale())
-                .statFemale(exhibitionDto.getStatFemale())
-                .statAge10(exhibitionDto.getStatAge10())
-                .statAge20(exhibitionDto.getStatAge20())
-                .statAge30(exhibitionDto.getStatAge30())
-                .statAge40(exhibitionDto.getStatAge40())
-                .statAge50(exhibitionDto.getStatAge50())
-                .mainImgUrl(exhibitionDto.getMainImgUrl())
-                .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
-                .detailImgUrl(exhibitionDto.getDetailImgUrl())
-                .build());
+            .id(exhibitionDto.getId())
+            .name(exhibitionDto.getName())
+            .startsAt(exhibitionDto.getStartsAt())
+            .endsAt(exhibitionDto.getEndsAt())
+            .price(exhibitionDto.getPrice())
+            .ageLimit(exhibitionDto.getAgeLimit())
+            .detailInfo(exhibitionDto.getDetailInfo())
+            .galleryLocation(exhibitionDto.getGalleryLocation())
+            .galleryId(exhibitionDto.getGallery().getId())
+            .statMale(exhibitionDto.getStatMale())
+            .statFemale(exhibitionDto.getStatFemale())
+            .statAge10(exhibitionDto.getStatAge10())
+            .statAge20(exhibitionDto.getStatAge20())
+            .statAge30(exhibitionDto.getStatAge30())
+            .statAge40(exhibitionDto.getStatAge40())
+            .statAge50(exhibitionDto.getStatAge50())
+            .mainImgUrl(exhibitionDto.getMainImgUrl())
+            .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
+            .detailImgUrl(exhibitionDto.getDetailImgUrl())
+            .build());
     }
 
     // 북마크 추가
@@ -95,4 +97,14 @@ public class ExhibitionController {
         return Response.success(bookmarkAddResponse);
     }
 
+    @PutMapping("/{exhibitionId}/edit")
+    @Operation(summary = "전시회 게시물 수정")
+    public Response edit(@PathVariable Long exhibitionId, @RequestBody ExhibitionEditRequest exhibitionEditRequest,
+        Authentication authentication) {
+
+        ExhibitionDto exhibitionDto = exhibitionService.edit(exhibitionId, exhibitionEditRequest,
+            authentication.getName());
+
+        return Response.success(exhibitionDto);
+    }
 }

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionEditRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionEditRequest.java
@@ -1,0 +1,70 @@
+package com.dev.museummate.domain.dto.exhibition;
+
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.GalleryEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @Builder
+@AllArgsConstructor
+public class ExhibitionEditRequest {
+
+    private Long id;
+
+    private String name;
+    private String startsAt;
+    private String endsAt;
+    private String price;
+    private String ageLimit;
+    private String detailInfo;
+    private String galleryLocation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gallery_id")
+    private GalleryEntity gallery;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private String statMale;
+    private String statFemale;
+    private String statAge10;
+    private String statAge20;
+    private String statAge30;
+    private String statAge40;
+    private String statAge50;
+    private String mainImgUrl;
+    private String noticeImgUrl;
+    private String detailImgUrl;
+
+    public ExhibitionEntity toEntity(UserEntity user) {
+
+        return ExhibitionEntity.builder()
+                .name(this.name)
+                .startsAt(this.startsAt)
+                .endsAt(this.endsAt)
+                .price(this.price)
+                .ageLimit(this.ageLimit)
+                .detailInfo(this.detailInfo)
+                .galleryLocation(this.galleryLocation)
+                .gallery(this.gallery)
+                .user(user)
+                .statMale(null)
+                .statFemale(null)
+                .statAge10(null)
+                .statAge20(null)
+                .statAge30(null)
+                .statAge40(null)
+                .statAge50(null)
+                .mainImgUrl(this.mainImgUrl)
+                .noticeImgUrl(this.noticeImgUrl)
+                .detailImgUrl(this.detailImgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/exception/ErrorCode.java
+++ b/src/main/java/com/dev/museummate/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "email conflict"),
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "Post Not Found"),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"email not found"),
+    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Unauthorized access" ),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "invalid password"),
     INVALID_REQUEST(HttpStatus.UNAUTHORIZED, "invalid quest"),
     USERNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "Username Not Found"),
@@ -19,6 +20,7 @@ public enum ErrorCode {
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Token not found"),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "Access forbidden"),
     EXHIBITION_NOT_FOUND(HttpStatus.NOT_FOUND, "Exhibition not found"),
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Database Error" )
     ;
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/dev/museummate/service/ExhibitionService.java
+++ b/src/main/java/com/dev/museummate/service/ExhibitionService.java
@@ -2,6 +2,7 @@ package com.dev.museummate.service;
 
 import com.dev.museummate.domain.dto.exhibition.BookmarkAddResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionDto;
+import com.dev.museummate.domain.dto.exhibition.ExhibitionEditRequest;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionWriteRequest;
 import com.dev.museummate.domain.entity.BookmarkEntity;
 import com.dev.museummate.domain.entity.ExhibitionEntity;
@@ -90,4 +91,22 @@ public class ExhibitionService {
         }
     }
 
+    public ExhibitionEntity getExihibitionById(Long exhibitionId) {
+
+        return exhibitionRepository.findById(exhibitionId).orElseThrow(() ->
+            new AppException(ErrorCode.NOT_FOUND_POST, String.format("해당 포스트는 존재하지 않습니다.")));
+    }
+
+    public ExhibitionDto edit(Long exhibitionId, ExhibitionEditRequest exhibitionEditRequest, String email) {
+
+        UserEntity user = userRepository.findByEmail(email).orElseThrow(() ->
+            new AppException(ErrorCode.EMAIL_NOT_FOUND, "존재하지 않는 유저입니다."));
+
+        ExhibitionEntity exhibitionEntity = getExihibitionById(exhibitionId);
+
+        ExhibitionEntity savedExhibition = exhibitionRepository.save(exhibitionEditRequest.toEntity(user));
+        ExhibitionDto exhibitionDto = ExhibitionDto.toDto(savedExhibition);
+
+        return exhibitionDto;
+    }
 }


### PR DESCRIPTION
## :information_desk_person: 간단 소개

전시회 수정 API 구현("/{exhibitionId}/edit")
전시회 수정 테스트코드 작성

## :heavy_check_mark: 작업 내용 설명
 - 전시회 정보 수정 성공, 수정 실패(DB 에러), 수정 실패(작성자 불일치)로 나누어 테스트 코드 구현했습니다.

## :bulb: 참고사항
로직 변경 등 리뷰어나 다른 팀원들이 참고해야 할 사항을 적어주세요.
