### PR TITLE
88 함께 전시 관람 글 작성 기능 추가

### DIFF
--- a/src/main/java/com/dev/museummate/controller/GatheringController.java
+++ b/src/main/java/com/dev/museummate/controller/GatheringController.java
@@ -1,0 +1,28 @@
+package com.dev.museummate.controller;
+
+import com.dev.museummate.configuration.Response;
+import com.dev.museummate.domain.dto.gathering.GatheringDto;
+import com.dev.museummate.domain.dto.gathering.GatheringPostRequest;
+import com.dev.museummate.domain.dto.gathering.GatheringPostResponse;
+import com.dev.museummate.service.GatheringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/gathering")
+public class GatheringController {
+
+    private final GatheringService gatheringService;
+
+    @PostMapping("/posts")
+    public Response<GatheringPostResponse> posts(@RequestBody GatheringPostRequest gatheringPostRequest, Authentication authentication) {
+
+        GatheringDto gatheringDto = gatheringService.posts(gatheringPostRequest,authentication.getName());
+        return Response.success(new GatheringPostResponse(gatheringDto.getId()));
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringDto.java
@@ -1,0 +1,54 @@
+package com.dev.museummate.domain.dto.gathering;
+
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.GatheringEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GatheringDto {
+
+    private Long id;
+    private String meetDateTime;
+    private String meetLocation;
+    private Integer maxPeople;
+    private String title;
+    private String content;
+    private Boolean close;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastModifiedAt;
+    private LocalDateTime deletedAt;
+    private String createdBy;
+    private String lastModifiedBy;
+
+    public GatheringDto(Long id, String meetDateTime, String meetLocation, Integer maxPeople, String title, String content, Boolean close) {
+        this.id = id;
+        this.meetDateTime = meetDateTime;
+        this.meetLocation = meetLocation;
+        this.maxPeople = maxPeople;
+        this.title = title;
+        this.content = content;
+        this.close = close;
+    }
+
+    public GatheringEntity toEntity(UserEntity user, ExhibitionEntity exhibition) {
+
+        return GatheringEntity.builder()
+                              .meetDateTime(this.meetDateTime)
+                              .meetLocation(this.meetLocation)
+                              .maxPeople(this.maxPeople)
+                              .title(this.title)
+                              .content(this.content)
+                              .close(this.close)
+                              .user(user)
+                              .exhibition(exhibition)
+                              .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostRequest.java
@@ -1,0 +1,32 @@
+package com.dev.museummate.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GatheringPostRequest {
+
+    private Long exhibitionId;
+    private String meetDateTime;
+    private String meetLocation;
+    private Integer maxPeople;
+    private String title;
+    private String content;
+
+    public GatheringDto toDto() {
+
+        return GatheringDto.builder()
+                           .meetDateTime(this.meetDateTime)
+                           .meetLocation(this.meetLocation)
+                           .maxPeople(this.maxPeople)
+                           .title(this.title)
+                           .content(this.content)
+                           .close(Boolean.TRUE)
+                           .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostResponse.java
@@ -1,0 +1,13 @@
+package com.dev.museummate.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GatheringPostResponse {
+    private Long gatheringId;
+
+}

--- a/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
@@ -3,6 +3,7 @@ package com.dev.museummate.domain.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -31,4 +32,12 @@ public class CommentEntity extends BaseEntity {
     @JoinColumn(name = "gathering")
     private GatheringEntity gathering;
 
+    @Builder
+    public CommentEntity(Long id, UserEntity user, Long parentId, String content, GatheringEntity gathering) {
+        this.id = id;
+        this.user = user;
+        this.parentId = parentId;
+        this.content = content;
+        this.gathering = gathering;
+    }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
@@ -11,13 +11,13 @@ import org.hibernate.annotations.ColumnDefault;
 @Table(name = "comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CommentEntity extends BaseTimeEntity{
+public class CommentEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name="user_id")
+    @JoinColumn(name = "user_id")
     private UserEntity user;
 
     @ColumnDefault("0")
@@ -26,5 +26,9 @@ public class CommentEntity extends BaseTimeEntity{
 
     @NotNull
     private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "gathering")
+    private GatheringEntity gathering;
 
 }

--- a/src/main/java/com/dev/museummate/domain/entity/GatheringEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/GatheringEntity.java
@@ -1,0 +1,79 @@
+package com.dev.museummate.domain.entity;
+
+import com.dev.museummate.domain.dto.gathering.GatheringDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.catalina.User;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "Gathering")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE gathering SET deleted_at = current_timestamp where id = ?")
+@Where(clause = "deleted_at is NULL")
+public class GatheringEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String meetDateTime;
+    private String meetLocation;
+    private Integer maxPeople;
+    @NotNull
+    private String title;
+    @NotNull
+    private String content;
+    @NotNull
+    private Boolean close;
+
+    @ManyToOne
+    @JoinColumn(name = "exhibition_id")
+    private ExhibitionEntity exhibition;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Builder
+    public GatheringEntity(Long id, String meetDateTime, String meetLocation, Integer maxPeople, String title, String content,
+                           Boolean close,
+                           ExhibitionEntity exhibition, UserEntity user) {
+        this.id = id;
+        this.meetDateTime = meetDateTime;
+        this.meetLocation = meetLocation;
+        this.maxPeople = maxPeople;
+        this.title = title;
+        this.content = content;
+        this.close = close;
+        this.exhibition = exhibition;
+        this.user = user;
+    }
+
+    public GatheringDto of() {
+        return GatheringDto.builder()
+                           .id(this.id)
+                           .title(this.title)
+                           .content(this.content)
+                           .meetLocation(this.meetLocation)
+                           .meetDateTime(this.meetDateTime)
+                           .maxPeople(this.maxPeople)
+                           .close(this.close)
+                           .createdAt(this.getCreatedAt())
+                           .lastModifiedAt(this.getLastModifiedAt())
+                           .lastModifiedBy(this.getLastModifiedBy())
+                           .createdBy(this.getCreatedBy())
+                           .build();
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
@@ -1,0 +1,44 @@
+package com.dev.museummate.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "participant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE participant SET deleted_at = current_timestamp where id = ?")
+@Where(clause = "deleted_at is NULL")
+public class ParticipantEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+    @ManyToOne
+    @JoinColumn(name = "socialing_id")
+    private GatheringEntity gathering;
+    @NotNull
+    private Boolean hostFlag;
+
+    @Builder
+    public ParticipantEntity(UserEntity user, GatheringEntity gathering, Boolean hostFlag) {
+        this.user = user;
+        this.gathering = gathering;
+        this.hostFlag = hostFlag;
+    }
+}

--- a/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
@@ -35,10 +35,12 @@ public class ParticipantEntity extends BaseTimeEntity {
     @NotNull
     private Boolean hostFlag;
 
-    @Builder
-    public ParticipantEntity(UserEntity user, GatheringEntity gathering, Boolean hostFlag) {
+    private Boolean approve;
+
+    public ParticipantEntity(UserEntity user, GatheringEntity gathering, Boolean hostFlag, Boolean approve) {
         this.user = user;
         this.gathering = gathering;
         this.hostFlag = hostFlag;
+        this.approve = approve;
     }
 }

--- a/src/main/java/com/dev/museummate/repository/GatheringRepository.java
+++ b/src/main/java/com/dev/museummate/repository/GatheringRepository.java
@@ -1,0 +1,8 @@
+package com.dev.museummate.repository;
+
+import com.dev.museummate.domain.entity.GatheringEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GatheringRepository extends JpaRepository<GatheringEntity, Long> {
+
+}

--- a/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
+++ b/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.dev.museummate.repository;
+
+import com.dev.museummate.domain.entity.ParticipantEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<ParticipantEntity,Long> {
+
+}

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -39,6 +39,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/example/security/admin").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout","/api/v1/users/modify","/api/v1/users/delete").authenticated()
                         .requestMatchers(HttpMethod.GET,"/api/v1/my/calendars").authenticated()
+                        .requestMatchers("/api/v1/gathering").authenticated()
                         .anyRequest().permitAll()   //고정
                 )
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -1,0 +1,47 @@
+package com.dev.museummate.service;
+
+import com.dev.museummate.domain.dto.gathering.GatheringDto;
+import com.dev.museummate.domain.dto.gathering.GatheringPostRequest;
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.GatheringEntity;
+import com.dev.museummate.domain.entity.ParticipantEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import com.dev.museummate.exception.AppException;
+import com.dev.museummate.exception.ErrorCode;
+import com.dev.museummate.repository.ExhibitionRepository;
+import com.dev.museummate.repository.GatheringRepository;
+import com.dev.museummate.repository.ParticipantRepository;
+import com.dev.museummate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GatheringService {
+
+    private final GatheringRepository gatheringRepository;
+    private final UserRepository userRepository;
+    private final ExhibitionRepository exhibitionRepository;
+    private final ParticipantRepository participantRepository;
+    public UserEntity findUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() ->
+                                                                 new AppException(ErrorCode.EMAIL_NOT_FOUND, String.format("%s님은 존재하지 않습니다.", email)));
+    }
+
+    public GatheringDto posts(GatheringPostRequest gatheringPostRequest, String email) {
+
+        UserEntity findUser = findUserByEmail(email);
+        ExhibitionEntity findExhibition = exhibitionRepository.findById(gatheringPostRequest.getExhibitionId())
+                                                              .orElseThrow(() -> new AppException(ErrorCode.EXHIBITION_NOT_FOUND,
+                                                                                                  "존재하지 않는 전시회입니다."));
+
+        GatheringDto gatheringDto = gatheringPostRequest.toDto();
+        GatheringEntity gatheringEntity = gatheringDto.toEntity(findUser, findExhibition);
+        GatheringEntity savedEntity = gatheringRepository.save(gatheringEntity);
+        GatheringDto savedDto = savedEntity.of();
+
+        participantRepository.save(new ParticipantEntity(findUser, savedEntity, Boolean.FALSE));
+
+        return savedDto;
+    }
+}

--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -40,7 +40,7 @@ public class GatheringService {
         GatheringEntity savedEntity = gatheringRepository.save(gatheringEntity);
         GatheringDto savedDto = savedEntity.of();
 
-        participantRepository.save(new ParticipantEntity(findUser, savedEntity, Boolean.FALSE));
+        participantRepository.save(new ParticipantEntity(findUser, savedEntity, Boolean.TRUE,Boolean.TRUE));
 
         return savedDto;
     }

--- a/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
@@ -1,0 +1,110 @@
+package com.dev.museummate.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dev.museummate.domain.dto.gathering.GatheringDto;
+import com.dev.museummate.domain.dto.gathering.GatheringPostRequest;
+import com.dev.museummate.exception.AppException;
+import com.dev.museummate.exception.ErrorCode;
+import com.dev.museummate.service.GatheringService;
+import com.dev.museummate.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(GatheringController.class)
+class GatheringControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    GatheringService gatheringService;
+
+    @Test
+    @DisplayName("모집 글 작성 - 성공")
+    @WithMockUser
+    void posts_success() throws Exception {
+
+        GatheringPostRequest gatheringPostRequest = new GatheringPostRequest(1L, "23/10/29", "한국", 3, "모집", "같이 갈 사람");
+
+        GatheringDto gatheringDto = new GatheringDto(1L, "23/10/29", "한국", 5, "제목", "내용", Boolean.TRUE);
+        //given
+        given(gatheringService.posts(any(), any()))
+            .willReturn(gatheringDto);
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/posts")
+                                              .with(csrf())
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(objectMapper.writeValueAsBytes(gatheringPostRequest)))
+               .andDo(print())
+               .andExpect(status().isOk());
+        //then
+
+    }
+
+    @Test
+    @DisplayName("모집 글 작성 - 실패#1 이메일 조회 불가")
+    @WithMockUser
+    void posts_fail_1() throws Exception {
+
+        GatheringPostRequest gatheringPostRequest = new GatheringPostRequest(1L, "23/10/29", "한국", 3, "모집", "같이 갈 사람");
+
+        GatheringDto gatheringDto = new GatheringDto(1L, "23/10/29", "한국", 5, "제목", "내용", Boolean.TRUE);
+        //given
+        given(gatheringService.posts(any(), any()))
+            .willThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND, ""));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/posts")
+                                              .with(csrf())
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(objectMapper.writeValueAsBytes(gatheringPostRequest)))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+        //then
+
+    }
+
+    @Test
+    @DisplayName("모집 글 작성 - 실패#2 전시회 조회 불가")
+    @WithMockUser
+    void posts_fail_2() throws Exception {
+
+        GatheringPostRequest gatheringPostRequest = new GatheringPostRequest(1L, "23/10/29", "한국", 3, "모집", "같이 갈 사람");
+
+        GatheringDto gatheringDto = new GatheringDto(1L, "23/10/29", "한국", 5, "제목", "내용", Boolean.TRUE);
+        //given
+        given(gatheringService.posts(any(), any()))
+            .willThrow(new AppException(ErrorCode.EXHIBITION_NOT_FOUND, ""));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/posts")
+                                              .with(csrf())
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(objectMapper.writeValueAsBytes(gatheringPostRequest)))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+        //then
+    }
+
+}


### PR DESCRIPTION
## :information_desk_person: 간단 소개
파티 모집 글 작성하는 기능을 추가했습니다

## :heavy_check_mark: 작업 내용 설명
### Entity
 review - 모집 글 댓글 작성을 위해 연관관계 추가했습니다
 gathering, participant entity를 생성했습니다.
### Repository
 gathering, participants repository를 생성했습니다.
### Service
 gathering Service 생성
 posts() 메서드 추가
### Controller
 gathering Controller 생성
 POST /api/v1/socialing/posts 메서드 추가

### Test Code
 파티 모집 글 등록 - 성공 200
 db에 없는 이메일로 접근 - 실패 404
 db에 없는 전시회 조회 - 실패 404

## :bulb: 참고사항
없습니다
