### PR TITLE
91 함께 전시 관람 신청 기능

### DIFF
--- a/src/main/java/com/dev/museummate/controller/GatheringController.java
+++ b/src/main/java/com/dev/museummate/controller/GatheringController.java
@@ -7,6 +7,7 @@ import com.dev.museummate.domain.dto.gathering.GatheringPostResponse;
 import com.dev.museummate.service.GatheringService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +25,11 @@ public class GatheringController {
 
         GatheringDto gatheringDto = gatheringService.posts(gatheringPostRequest,authentication.getName());
         return Response.success(new GatheringPostResponse(gatheringDto.getId()));
+    }
+
+    @PostMapping("/{gatheringId}/enroll")
+    public Response<String> enroll(@PathVariable Long gatheringId,Authentication authentication) {
+        String msg = gatheringService.enroll(gatheringId,authentication.getName());
+        return Response.success(msg);
     }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/CommentEntity.java
@@ -28,7 +28,7 @@ public class CommentEntity extends BaseEntity {
     private String content;
 
     @ManyToOne
-    @JoinColumn(name = "gathering")
+    @JoinColumn(name = "gathering_id")
     private GatheringEntity gathering;
 
 }

--- a/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
@@ -30,13 +30,14 @@ public class ParticipantEntity extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private UserEntity user;
     @ManyToOne
-    @JoinColumn(name = "socialing_id")
+    @JoinColumn(name = "gathering_id")
     private GatheringEntity gathering;
     @NotNull
     private Boolean hostFlag;
 
     private Boolean approve;
 
+    @Builder
     public ParticipantEntity(UserEntity user, GatheringEntity gathering, Boolean hostFlag, Boolean approve) {
         this.user = user;
         this.gathering = gathering;

--- a/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.springframework.security.core.parameters.P;
 
 @Entity
 @Table(name = "participant")
@@ -43,5 +44,13 @@ public class ParticipantEntity extends BaseTimeEntity {
         this.gathering = gathering;
         this.hostFlag = hostFlag;
         this.approve = approve;
+    }
+    public static ParticipantEntity of(UserEntity findUser,GatheringEntity findGathering,Boolean hostFlag,Boolean approve) {
+        return ParticipantEntity.builder()
+                                .user(findUser)
+                                .gathering(findGathering)
+                                .hostFlag(hostFlag)
+                                .approve(approve)
+                                .build();
     }
 }

--- a/src/main/java/com/dev/museummate/exception/ErrorCode.java
+++ b/src/main/java/com/dev/museummate/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Token not found"),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "Access forbidden"),
     EXHIBITION_NOT_FOUND(HttpStatus.NOT_FOUND, "Exhibition not found"),
+    GATHERING_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Gathering post not found"),
+    DUPLICATED_ENROLL(HttpStatus.CONFLICT, "User is Duplicate"),
     ;
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
+++ b/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
@@ -1,8 +1,11 @@
 package com.dev.museummate.repository;
 
 import com.dev.museummate.domain.entity.ParticipantEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ParticipantRepository extends JpaRepository<ParticipantEntity,Long> {
+public interface ParticipantRepository extends JpaRepository<ParticipantEntity, Long> {
+
+    Optional<ParticipantEntity> findByUserIdAndGatheringId(Long userId, Long gatheringId);
 
 }

--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -44,4 +44,19 @@ public class GatheringService {
 
         return savedDto;
     }
+
+    public String enroll(Long gatheringId, String email) {
+        UserEntity findUser = findUserByEmail(email);
+        GatheringEntity findGatheringPost = gatheringRepository.findById(gatheringId)
+                                                               .orElseThrow(() -> new AppException(ErrorCode.GATHERING_POST_NOT_FOUND,
+                                                                                                   "존재하지 않는 모집 글 입니다."));
+
+        participantRepository.findByUserIdAndGatheringId(findUser.getId(), findGatheringPost.getId())
+                             .ifPresent(p -> {
+                                 throw new AppException(ErrorCode.DUPLICATED_ENROLL, "이미 신청 되었습니다.");
+                             });
+
+        participantRepository.save(new ParticipantEntity(findUser, findGatheringPost, Boolean.FALSE, Boolean.FALSE));
+        return "신청이 완료 되었습니다.";
+    }
 }

--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -37,10 +37,10 @@ public class GatheringService {
 
         GatheringDto gatheringDto = gatheringPostRequest.toDto();
         GatheringEntity gatheringEntity = gatheringDto.toEntity(findUser, findExhibition);
-        GatheringEntity savedEntity = gatheringRepository.save(gatheringEntity);
-        GatheringDto savedDto = savedEntity.of();
+        GatheringEntity savedGathering = gatheringRepository.save(gatheringEntity);
+        GatheringDto savedDto = savedGathering.of();
 
-        participantRepository.save(new ParticipantEntity(findUser, savedEntity, Boolean.TRUE,Boolean.TRUE));
+        participantRepository.save(ParticipantEntity.of(findUser, savedGathering, Boolean.TRUE, Boolean.TRUE));
 
         return savedDto;
     }
@@ -56,7 +56,7 @@ public class GatheringService {
                                  throw new AppException(ErrorCode.DUPLICATED_ENROLL, "이미 신청 되었습니다.");
                              });
 
-        participantRepository.save(new ParticipantEntity(findUser, findGatheringPost, Boolean.FALSE, Boolean.FALSE));
+        participantRepository.save(ParticipantEntity.of(findUser, findGatheringPost, Boolean.FALSE, Boolean.FALSE));
         return "신청이 완료 되었습니다.";
     }
 }

--- a/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
@@ -107,4 +107,69 @@ class GatheringControllerTest {
         //then
     }
 
+    @Test
+    @DisplayName("참가 신청 - 성공")
+    @WithMockUser
+    void enroll_success() throws Exception {
+
+        given(gatheringService.enroll(any(), any()))
+            .willReturn("신청이 완료 되었습니다.");
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/1/enroll")
+                                              .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#1 이메일 조회 불가")
+    @WithMockUser
+    void enroll_fail_1() throws Exception {
+
+        given(gatheringService.enroll(any(), any()))
+            .willThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND, ""));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/1/enroll")
+                                              .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+        //then
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#2 모집 글 조회 불가")
+    @WithMockUser
+    void enroll_fail_2() throws Exception {
+
+        given(gatheringService.enroll(any(), any()))
+            .willThrow(new AppException(ErrorCode.GATHERING_POST_NOT_FOUND, ""));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/1/enroll")
+                                              .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+        //then
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#3 이미 신청한 회원이 중복 신청할 경우")
+    @WithMockUser
+    void enroll_fail_3() throws Exception {
+
+        given(gatheringService.enroll(any(), any()))
+            .willThrow(new AppException(ErrorCode.DUPLICATED_ENROLL, "중복된 신청입니다."));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/gathering/1/enroll")
+                                              .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isConflict());
+        //then
+    }
+
+
 }

--- a/src/test/java/com/dev/museummate/service/GatheringServiceTest.java
+++ b/src/test/java/com/dev/museummate/service/GatheringServiceTest.java
@@ -1,0 +1,124 @@
+package com.dev.museummate.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dev.museummate.domain.entity.ExhibitionEntity;
+import com.dev.museummate.domain.entity.GatheringEntity;
+import com.dev.museummate.domain.entity.ParticipantEntity;
+import com.dev.museummate.domain.entity.UserEntity;
+import com.dev.museummate.exception.AppException;
+import com.dev.museummate.exception.ErrorCode;
+import com.dev.museummate.repository.ExhibitionRepository;
+import com.dev.museummate.repository.GatheringRepository;
+import com.dev.museummate.repository.ParticipantRepository;
+import com.dev.museummate.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GatheringServiceTest {
+
+    GatheringService gatheringService;
+
+    GatheringRepository gatheringRepository = mock(GatheringRepository.class);
+    UserRepository userRepository = mock(UserRepository.class);
+    ExhibitionRepository exhibitionRepository = mock(ExhibitionRepository.class);
+    ParticipantRepository participantRepository = mock(ParticipantRepository.class);
+
+    @BeforeEach
+    public void setUp() {
+        gatheringService = new GatheringService(gatheringRepository, userRepository, exhibitionRepository, participantRepository);
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 성공")
+    public void post_success() {
+
+        ParticipantEntity mockParticipant = mock(ParticipantEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        GatheringEntity gathering = mock(GatheringEntity.class);
+
+        given(userRepository.findByEmail("email@naver.com"))
+            .willReturn(Optional.of(user));
+
+        given(gatheringRepository.findById(1L))
+            .willReturn(Optional.of(gathering));
+
+        given(participantRepository.save(any()))
+            .willReturn(mockParticipant);
+
+        String enroll = gatheringService.enroll(1L, "email@naver.com");
+        assertEquals(enroll,"신청이 완료 되었습니다.");
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#1 이메일 조회 불가")
+    public void post_fail_1() {
+
+        ParticipantEntity mockParticipant = mock(ParticipantEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        GatheringEntity gathering = mock(GatheringEntity.class);
+
+        given(userRepository.findByEmail("email@naver.com"))
+            .willThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND, ""));
+
+        try {
+            String enroll = gatheringService.enroll(1L, "email@naver.com");
+        } catch (Exception e) {
+            assertEquals(e.getMessage(),"email not found: ");
+        }
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#2 모집 글 조회 불가")
+    public void post_fail_2() {
+
+        ParticipantEntity mockParticipant = mock(ParticipantEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        GatheringEntity gathering = mock(GatheringEntity.class);
+
+        given(userRepository.findByEmail("email@naver.com"))
+            .willReturn(Optional.of(user));
+
+        given(gatheringRepository.findById(1L))
+            .willThrow(new AppException(ErrorCode.GATHERING_POST_NOT_FOUND, ""));
+
+        try {
+            String enroll = gatheringService.enroll(1L, "email@naver.com");
+        } catch (Exception e) {
+            assertEquals(e.getMessage(),"Gathering post not found: ");
+        }
+    }
+
+    @Test
+    @DisplayName("참가 신청 - 실패#3 이미 신청한 회원이 중복 신청할 경우")
+    public void post_fail_3() {
+
+        ParticipantEntity mockParticipant = mock(ParticipantEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        GatheringEntity gathering = mock(GatheringEntity.class);
+
+        given(userRepository.findByEmail("email@naver.com"))
+            .willReturn(Optional.of(user));
+
+        given(gatheringRepository.findById(1L))
+            .willReturn(Optional.of(gathering));
+
+        given(participantRepository.findByUserIdAndGatheringId(1L, 1L))
+            .willThrow(new AppException(ErrorCode.DUPLICATED_ENROLL, ""));
+
+        try {
+            String enroll = gatheringService.enroll(1L, "email@naver.com");
+        } catch (Exception e) {
+            assertEquals(e.getMessage(),"User is Duplicate");
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
## :information_desk_person: 간단 소개
#91 
함께 전시 관람 모집 글을 보고 신청하는 기능입니다.
Controller,service에 enroll()을 통해서 신청하도록 만들었습니다
### Controller
호출 후 성공하면 String 반환
### Service
user 조회, 모집 글 조회, 중복 신청 3개를 조회 한 뒤 예외가 발생하지 않을 경우 
ParticipantEntity 생성 후 저장합니다.  

## :heavy_check_mark: 작업 내용 설명
### GatheringController
enroll() 메서드 추가
### GatheringService
enroll() 메서드 추가
### ParticipantRepository
findByUserIdAndGatheringId 메서드 추가
### ErrorCode
GATHERING_POST_NOT_FOUND,DUPLICATED_ENROLL 추가
### Test
성공
실패-1 이메일 조회 불가
실패-2 모집 글 조회 불가
실패-3 이미 신청한 회원이 중복신청할 경우
## :bulb: 참고사항
@JoinColumn name 잘 못되어있는 부분도 같이 수정했습니다.
Service도 test 추가했습니다