### PR TITLE
103 함께 전시 관람 승인 기능

### DIFF
--- a/src/main/java/com/dev/museummate/controller/GatheringController.java
+++ b/src/main/java/com/dev/museummate/controller/GatheringController.java
@@ -35,6 +35,11 @@ public class GatheringController {
         String msg = gatheringService.enroll(gatheringId,authentication.getName());
         return Response.success(msg);
     }
+    @GetMapping("/{gatheringId}/enroll/{participantId}")
+    public Response<String> approve(@PathVariable Long gatheringId,@PathVariable Long participantId, Authentication authentication) {
+        String msg = gatheringService.approve(gatheringId,participantId,authentication.getName());
+        return Response.success(msg);
+    }
 
     @GetMapping("/{gatheringId}/enroll/list")
     public Response<List<GatheringResponse>> enrollList(@PathVariable Long gatheringId, Authentication authentication) {
@@ -47,4 +52,5 @@ public class GatheringController {
         List<GatheringResponse> approveList = gatheringService.approveList(gatheringId);
         return Response.success(approveList);
     }
+
 }

--- a/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/gathering/GatheringPostRequest.java
@@ -26,7 +26,7 @@ public class GatheringPostRequest {
                            .maxPeople(this.maxPeople)
                            .title(this.title)
                            .content(this.content)
-                           .close(Boolean.TRUE)
+                           .close(Boolean.FALSE)
                            .build();
     }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/GatheringEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/GatheringEntity.java
@@ -76,4 +76,13 @@ public class GatheringEntity extends BaseEntity {
                            .createdBy(this.getCreatedBy())
                            .build();
     }
+
+
+    public void openPost() {
+        this.close = Boolean.FALSE;
+    }
+
+    public void closePost() {
+        this.close = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ParticipantEntity.java
@@ -56,4 +56,7 @@ public class ParticipantEntity extends BaseTimeEntity {
 
     }
 
+    public void approveUser() {
+        this.approve = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/dev/museummate/exception/ErrorCode.java
+++ b/src/main/java/com/dev/museummate/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     EXHIBITION_NOT_FOUND(HttpStatus.NOT_FOUND, "Exhibition not found"),
     GATHERING_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Gathering post not found"),
     DUPLICATED_ENROLL(HttpStatus.CONFLICT, "User is Duplicate"),
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "Participant not found"),
     ;
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
+++ b/src/main/java/com/dev/museummate/repository/ParticipantRepository.java
@@ -9,5 +9,5 @@ public interface ParticipantRepository extends JpaRepository<ParticipantEntity, 
 
     Optional<ParticipantEntity> findByUserIdAndGatheringId(Long userId, Long gatheringId);
     List<ParticipantEntity> findAllByGatheringIdAndApprove(Long gatheringId, Boolean approve);
-
+    Integer countByGatheringIdAndApproveTrue(Long gatheringId);
 }

--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -13,6 +13,8 @@ import com.dev.museummate.repository.ExhibitionRepository;
 import com.dev.museummate.repository.GatheringRepository;
 import com.dev.museummate.repository.ParticipantRepository;
 import com.dev.museummate.repository.UserRepository;
+import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -92,5 +94,24 @@ public class GatheringService {
                                                                      .collect(Collectors.toList());
 
         return participantList;
+    }
+
+    @Transactional
+    public String approve(Long gatheringId, Long participantId, String email) {
+
+        UserEntity findUser = findUserByEmail(email);
+        GatheringEntity findGatheringPost = gatheringRepository.findById(gatheringId)
+                                                               .orElseThrow(() -> new AppException(ErrorCode.GATHERING_POST_NOT_FOUND,
+                                                                                                   "존재하지 않는 모집 글 입니다."));
+        if (!findUser.getId().equals(findGatheringPost.getUser().getId())) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "글 작성자만 조회 가능합니다.");
+        }
+
+        ParticipantEntity participant = participantRepository.findById(participantId)
+                                                             .orElseThrow(() -> new AppException(ErrorCode.PARTICIPANT_NOT_FOUND,
+                                                                                                 "존재하지 않는 참여자 입니다."));
+        participant.approveUser();
+        participantRepository.save(participant);
+        return "신청을 승인 했습니다.";
     }
 }

--- a/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
@@ -232,5 +232,74 @@ class GatheringControllerTest {
         //then
     }
 
+    @Test
+    @DisplayName("참가 신청 승인 - 성공")
+    @WithMockUser
+    void approve_success() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willReturn("신청을 승인합니다.");
+
+        mockMvc.perform(get("/api/v1/gathering/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("참가 신청 승인 - 실패#1 이메일 조회 실패")
+    @WithMockUser
+    void approve_fail_1() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willThrow(new AppException(ErrorCode.EMAIL_NOT_FOUND,""));
+
+        mockMvc.perform(get("/api/v1/gathering/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("참가 신청 승인 - 실패#2 모집글 조회 실패")
+    @WithMockUser
+    void approve_fail_2() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willThrow(new AppException(ErrorCode.GATHERING_POST_NOT_FOUND,""));
+
+        mockMvc.perform(get("/api/v1/gathering/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("참가 신청 승인 - 실패#3 모집 글 작성자가 아닌 사람이 조회 시도")
+    @WithMockUser
+    void approve_fail_3() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willThrow(new AppException(ErrorCode.INVALID_REQUEST,""));
+
+        mockMvc.perform(get("/api/v1/gathering/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("참가 신청 승인 - 실패#4 참가 신청자 조회 실패")
+    @WithMockUser
+    void approve_fail_4() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willThrow(new AppException(ErrorCode.PARTICIPANT_NOT_FOUND,""));
+
+        mockMvc.perform(get("/api/v1/gathering/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isNotFound());
+    }
 
 }


### PR DESCRIPTION
## :information_desk_person: 간단 소개
#103 
GET '/api/v1/gathering/{gatheringId}/enroll/{enrollId}'
enrollId로 조회해서 참가자를 승인합니다(글 작성자만 가능합니다)

## :heavy_check_mark: 작업 내용 설명
### Controller
 apprve() 메서드 추가
### Service
 apprve() 메서드 추가

### Test
 성공 - 200
 실패 - 이메일 조회 실패 - 404
 실패 - 모집 글 조회 실패 - 404
 실패 - 모집 글 작성자가 아닌 사람이 조회 시도 - 401
 실패 - 참가 신청자 조회 실패 - 404
