### PR TITLE
Feat: Cors 일부 허용

### DIFF
--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
      CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
-        configuration.setAllowedMethods(Arrays.asList("GET","POST"));
+        configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE"));
         configuration.addAllowedHeader("*");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -12,6 +12,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @EnableWebSecurity
 @Configuration
@@ -49,5 +54,16 @@ public class SecurityConfiguration {
                 .addFilterBefore(new JwtFilter(jwtUtils, redisDao, secretKey), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(), JwtFilter.class)
                 .build();
+    }
+    @Bean
+     CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET","POST"));
+        configuration.addAllowedHeader("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
## :information_desk_person: 간단 소개
Security 단에서 cors를 일부 허용해주는 건에 대한 request입니다.

## :heavy_check_mark: 작업 내용 설명
프론트 서버에서 api 요청으로 할때 cors로 인해 요청이 막히는 문제가 발생하여 security에서 cors 설정을 3000 포트에서 오는 요청은 허용해주도록 수정했습니다.

## :bulb: 참고사항
추후에 배포할 때는 url을 localhost:3000이 아니라 배포된 프론트 서버의 주소로 설정해야 할 것 같습니다.