### PR TITLE
Fix: 리뷰 등록 기능에 쓰이는 dto 수정

### DIFF
--- a/src/main/java/com/dev/museummate/domain/dto/review/WriteReviewResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/review/WriteReviewResponse.java
@@ -19,6 +19,7 @@ public class WriteReviewResponse {
     private String visitedDate;
     private LocalDateTime createdAt; // 최초 생성 일시
     private LocalDateTime lastModifiedAt; // 최종 수정 일시
+    private Boolean isDeleted;
     private String createdBy; // 최소 생성 사용자 userName
     private String lastModifiedBy; // 최종 수정 사용자 userName
     // private String message; // 리뷰 등록 성공
@@ -35,6 +36,7 @@ public class WriteReviewResponse {
             reviewDto.getVisitedDate(),
             reviewDto.getCreatedAt(),
             reviewDto.getLastModifiedAt(),
+            reviewDto.getIsDeleted(),
             reviewDto.getCreatedBy(),
             reviewDto.getLastModifiedBy()
         );

--- a/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
+++ b/src/main/java/com/dev/museummate/security/SecurityConfiguration.java
@@ -46,6 +46,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/example/security/admin").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/reissue","/api/v1/users/logout","/api/v1/users/modify","/api/v1/users/delete").authenticated()
                         .requestMatchers(HttpMethod.GET,"/api/v1/my/calendars","/api/v1/my/**").authenticated()
+                        .requestMatchers(HttpMethod.POST,"/api/v1/reviews/**").authenticated() // 추가
                         .requestMatchers("/api/v1/gathering").authenticated()
                         .anyRequest().permitAll()   //고정
                 )

--- a/src/main/java/com/dev/museummate/service/ReviewService.java
+++ b/src/main/java/com/dev/museummate/service/ReviewService.java
@@ -54,6 +54,7 @@ public class ReviewService {
                 .visitedDate(writeReviewRequest.getVisitedDate())
                 .user(user)
                 .exhibition(exhibition)
+                .isDeleted(Boolean.FALSE)
                 .build();
 
         // db에 review를 저장


### PR DESCRIPTION
## :information_desk_person: 간단 소개
리뷰 등록 기능 api 테스트 시 발생하는 500 에러를 수정하였습니다.

## :heavy_check_mark: 작업 내용 설명
리뷰 crud 순으로 만들면서 삭제 기능 구현에 따라 추가된 is_deleted 컬럼이 리뷰 등록 기능 관련 dto에 반영되지 않아, 리뷰 등록 기능 테스트 시 500 에러가 발생합니다. 
Response 객체와 Service 레이어의 리뷰 등록 메서드를 모두 수정하였습니다. 

## :bulb: 참고사항
유닛 테스트 (컨트롤러)는 아직 수정 전입니다. 참고 바랍니다! 
