### PR TITLE
147 exhibition 관련 누락 항목 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/dev/museummate/controller/ExhibitionController.java
+++ b/src/main/java/com/dev/museummate/controller/ExhibitionController.java
@@ -8,6 +8,7 @@ import com.dev.museummate.domain.dto.exhibition.ExhibitionResponse;
 import com.dev.museummate.domain.dto.exhibition.ExhibitionWriteRequest;
 import com.dev.museummate.service.ExhibitionService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,8 +54,21 @@ public class ExhibitionController {
 
     // 전시회 전체 조회
     @GetMapping
-    public Response<Page<ExhibitionResponse>> findAllExhibitions(@PageableDefault(size = 20,
-                                                                                  sort = "name", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<ExhibitionResponse>> findAllExhibitions(
+        @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+        @RequestParam("sort") String sort,
+        @RequestParam("price") Optional<String> price) {
+
+        String p = price.orElse("");
+
+        if (p.equals("무료")) {
+            Page<ExhibitionDto> exhibitionDtos = exhibitionService.findAllByPrice(pageable, p);
+            return Response.success(ExhibitionResponse.of(exhibitionDtos));
+
+        } else if (p.equals("유료")) {
+            Page<ExhibitionDto> exhibitionDtos = exhibitionService.findAllByPrice(pageable, p);
+            return Response.success(ExhibitionResponse.of(exhibitionDtos));
+        }
         Page<ExhibitionDto> exhibitionDtos = exhibitionService.findAllExhibitions(pageable);
         return Response.success(ExhibitionResponse.of(exhibitionDtos));
     }

--- a/src/main/java/com/dev/museummate/controller/ExhibitionController.java
+++ b/src/main/java/com/dev/museummate/controller/ExhibitionController.java
@@ -39,6 +39,7 @@ public class ExhibitionController {
                                                   .detailInfo(exhibitionDto.getDetailInfo())
                                                   .galleryLocation(exhibitionDto.getGalleryLocation())
                                                   .galleryName(exhibitionDto.getGalleryName())
+                                                  .notice(exhibitionDto.getNotice())
                                                   .statMale(exhibitionDto.getStatMale())
                                                   .statFemale(exhibitionDto.getStatFemale())
                                                   .statAge10(exhibitionDto.getStatAge10())
@@ -48,7 +49,7 @@ public class ExhibitionController {
                                                   .statAge50(exhibitionDto.getStatAge50())
                                                   .mainImgUrl(exhibitionDto.getMainImgUrl())
                                                   .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
-                                                  .detailImgUrl(exhibitionDto.getDetailImgUrl())
+                                                  .detailInfoImgUrl(exhibitionDto.getDetailInfoImgUrl())
                                                   .build());
     }
 
@@ -89,6 +90,7 @@ public class ExhibitionController {
                                                   .detailInfo(exhibitionDto.getDetailInfo())
                                                   .galleryLocation(exhibitionDto.getGalleryLocation())
                                                   .galleryName(exhibitionDto.getGalleryName())
+                                                  .notice(exhibitionDto.getNotice())
                                                   .statMale(exhibitionDto.getStatMale())
                                                   .statFemale(exhibitionDto.getStatFemale())
                                                   .statAge10(exhibitionDto.getStatAge10())
@@ -98,7 +100,7 @@ public class ExhibitionController {
                                                   .statAge50(exhibitionDto.getStatAge50())
                                                   .mainImgUrl(exhibitionDto.getMainImgUrl())
                                                   .noticeImgUrl(exhibitionDto.getNoticeImgUrl())
-                                                  .detailImgUrl(exhibitionDto.getDetailImgUrl())
+                                                  .detailInfoImgUrl(exhibitionDto.getDetailInfoImgUrl())
                                                   .build());
     }
 

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionDto.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionDto.java
@@ -23,6 +23,7 @@ public class ExhibitionDto {
     private String galleryLocation;
 
     private String galleryName;
+    private String notice;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -37,13 +38,13 @@ public class ExhibitionDto {
     private String statAge50;
     private String mainImgUrl;
     private String noticeImgUrl;
-    private String detailImgUrl;
+    private String detailInfoImgUrl;
 
     @Builder
     public ExhibitionDto(Long id, String name, String startAt, String endAt, String price, String ageLimit, String detailInfo,
-                         String galleryLocation, String galleryName, UserEntity user, String statMale, String statFemale, String statAge10,
-                         String statAge20, String statAge30, String statAge40, String statAge50, String mainImgUrl, String noticeImgUrl,
-                         String detailImgUrl) {
+                         String galleryLocation, String galleryName, String notice, UserEntity user, String statMale, String statFemale,
+                         String statAge10, String statAge20, String statAge30, String statAge40, String statAge50, String mainImgUrl,
+                         String noticeImgUrl, String detailInfoImgUrl) {
         this.id = id;
         this.name = name;
         this.startAt = startAt;
@@ -53,6 +54,7 @@ public class ExhibitionDto {
         this.detailInfo = detailInfo;
         this.galleryLocation = galleryLocation;
         this.galleryName = galleryName;
+        this.notice = notice;
         this.user = user;
         this.statMale = statMale;
         this.statFemale = statFemale;
@@ -63,7 +65,7 @@ public class ExhibitionDto {
         this.statAge50 = statAge50;
         this.mainImgUrl = mainImgUrl;
         this.noticeImgUrl = noticeImgUrl;
-        this.detailImgUrl = detailImgUrl;
+        this.detailInfoImgUrl = detailInfoImgUrl;
     }
 
     /**
@@ -81,6 +83,7 @@ public class ExhibitionDto {
                 .detailInfo(exhibitionEntity.getDetailInfo())
                 .galleryLocation(exhibitionEntity.getGalleryLocation())
                 .galleryName(exhibitionEntity.getGalleryName())
+                .notice(exhibitionEntity.getNotice())
                 .user(exhibitionEntity.getUser())
                 .statMale(exhibitionEntity.getStatMale())
                 .statFemale(exhibitionEntity.getStatFemale())
@@ -91,7 +94,7 @@ public class ExhibitionDto {
                 .statAge50(exhibitionEntity.getStatAge_50())
                 .mainImgUrl(exhibitionEntity.getMainImgUrl())
                 .noticeImgUrl(exhibitionEntity.getNoticeImgUrl())
-                .detailImgUrl(exhibitionEntity.getDetailImgUrl())
+                .detailInfoImgUrl(exhibitionEntity.getDetailInfoImgUrl())
                 .build();
     }
 }

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionEditRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionEditRequest.java
@@ -37,7 +37,7 @@ public class ExhibitionEditRequest {
     private String statAge_50;
     private String mainImgUrl;
     private String noticeImgUrl;
-    private String detailImgUrl;
+    private String detailInfoImgUrl;
 
     public ExhibitionEntity toEntity(UserEntity user) {
 
@@ -60,7 +60,7 @@ public class ExhibitionEditRequest {
                 .statAge_50(null)
                 .mainImgUrl(this.mainImgUrl)
                 .noticeImgUrl(this.noticeImgUrl)
-                .detailImgUrl(this.detailImgUrl)
+                .detailInfoImgUrl(this.detailInfoImgUrl)
                 .build();
     }
 }

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionResponse.java
@@ -22,6 +22,7 @@ public class ExhibitionResponse {
     private String detailInfo;
     private String galleryLocation;
     private String galleryName;
+    private String notice;
     private String statMale;
     private String statFemale;
     private String statAge10;
@@ -31,7 +32,7 @@ public class ExhibitionResponse {
     private String statAge50;
     private String mainImgUrl;
     private String noticeImgUrl;
-    private String detailImgUrl;
+    private String detailInfoImgUrl;
 
     public static Page<ExhibitionResponse> of(Page<ExhibitionDto> exhibitions) {
         return exhibitions.map(exhibition -> ExhibitionResponse.builder()
@@ -44,6 +45,7 @@ public class ExhibitionResponse {
                 .detailInfo(exhibition.getDetailInfo())
                 .galleryLocation(exhibition.getGalleryLocation())
                 .galleryName(exhibition.getGalleryName())
+                .notice(exhibition.getNotice())
                 .statMale(exhibition.getStatMale())
                 .statFemale(exhibition.getStatFemale())
                 .statAge10(exhibition.getStatAge10())
@@ -53,7 +55,7 @@ public class ExhibitionResponse {
                 .statAge50(exhibition.getStatAge50())
                 .mainImgUrl(exhibition.getMainImgUrl())
                 .noticeImgUrl(exhibition.getNoticeImgUrl())
-                .detailImgUrl(exhibition.getDetailImgUrl())
+                .detailInfoImgUrl(exhibition.getDetailInfoImgUrl())
                 .build());
     }
 
@@ -68,6 +70,7 @@ public class ExhibitionResponse {
                 .detailInfo(exhibition.getDetailInfo())
                 .galleryLocation(exhibition.getGalleryLocation())
                 .galleryName(exhibition.getGalleryName())
+                .notice(exhibition.getNotice())
                 .statMale(exhibition.getStatMale())
                 .statFemale(exhibition.getStatFemale())
                 .statFemale(exhibition.getStatAge10())
@@ -78,7 +81,7 @@ public class ExhibitionResponse {
                 .statAge50(exhibition.getStatAge50())
                 .mainImgUrl(exhibition.getMainImgUrl())
                 .noticeImgUrl(exhibition.getNoticeImgUrl())
-                .detailImgUrl(exhibition.getDetailImgUrl())
+                .detailInfoImgUrl(exhibition.getDetailInfoImgUrl())
                 .build();
     }
 }

--- a/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionWriteRequest.java
+++ b/src/main/java/com/dev/museummate/domain/dto/exhibition/ExhibitionWriteRequest.java
@@ -21,11 +21,11 @@ public class ExhibitionWriteRequest {
     private String galleryName;
     private String mainImgUrl;
     private String noticeImgUrl;
-    private String detailImgUrl;
+    private String detailInfoImgUrl;
 
     @Builder
     public ExhibitionWriteRequest(String name, String startAt, String endAt, String price, String ageLimit, String detailInfo,
-                                  String galleryLocation, String galleryName, String mainImgUrl, String noticeImgUrl, String detailImgUrl) {
+                                  String galleryLocation, String galleryName, String mainImgUrl, String noticeImgUrl, String detailInfoImgUrl) {
         this.name = name;
         this.startAt = startAt;
         this.endAt = endAt;
@@ -36,7 +36,7 @@ public class ExhibitionWriteRequest {
         this.galleryName = galleryName;
         this.mainImgUrl = mainImgUrl;
         this.noticeImgUrl = noticeImgUrl;
-        this.detailImgUrl = detailImgUrl;
+        this.detailInfoImgUrl = detailInfoImgUrl;
     }
 
     public ExhibitionEntity toEntity(UserEntity user) {
@@ -60,7 +60,7 @@ public class ExhibitionWriteRequest {
                 .statAge_50(null)
                 .mainImgUrl(this.mainImgUrl)
                 .noticeImgUrl(this.noticeImgUrl)
-                .detailImgUrl(this.detailImgUrl)
+                .detailInfoImgUrl(this.detailInfoImgUrl)
                 .build();
     }
 }

--- a/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
+++ b/src/main/java/com/dev/museummate/domain/entity/ExhibitionEntity.java
@@ -40,15 +40,16 @@ public class ExhibitionEntity {
     private String statAge_50;
     private String mainImgUrl;
     private String noticeImgUrl;
-    private String detailImgUrl;
+    private String detailInfoImgUrl;
     private String galleryName;
+    private String notice;
 
     @Builder
     public ExhibitionEntity(Long id, String name, String startAt, String endAt, String price, String ageLimit, String detailInfo,
                             String galleryLocation, UserEntity user, String statMale, String statFemale, String statAge_10,
                             String statAge_20,
                             String statAge_30, String statAge_40, String statAge_50, String mainImgUrl, String noticeImgUrl,
-                            String detailImgUrl, String galleryName) {
+                            String detailInfoImgUrl, String galleryName, String notice) {
         this.id = id;
         this.name = name;
         this.startAt = startAt;
@@ -67,7 +68,8 @@ public class ExhibitionEntity {
         this.statAge_50 = statAge_50;
         this.mainImgUrl = mainImgUrl;
         this.noticeImgUrl = noticeImgUrl;
-        this.detailImgUrl = detailImgUrl;
+        this.detailInfoImgUrl = detailInfoImgUrl;
         this.galleryName = galleryName;
+        this.notice = notice;
     }
 }

--- a/src/main/java/com/dev/museummate/repository/ExhibitionRepository.java
+++ b/src/main/java/com/dev/museummate/repository/ExhibitionRepository.java
@@ -1,9 +1,14 @@
 package com.dev.museummate.repository;
 
 import com.dev.museummate.domain.entity.ExhibitionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExhibitionRepository extends JpaRepository<ExhibitionEntity, Long> {
     //    Page<ExhibitionEntity> findAll(Pageable pageable, ExhibitionEntity exhibition);
 
+    Page<ExhibitionEntity> findAll(Pageable pageable);
+    Page<ExhibitionEntity> findAllByPrice(Pageable pageable, String price);
+    Page<ExhibitionEntity> findAllByPriceNot(Pageable pageable, String price);
 }

--- a/src/main/java/com/dev/museummate/service/ExhibitionService.java
+++ b/src/main/java/com/dev/museummate/service/ExhibitionService.java
@@ -33,6 +33,18 @@ public class ExhibitionService {
         return exhibitionEntities.map(exhibition -> ExhibitionDto.toDto(exhibition));
     }
 
+    public Page<ExhibitionDto> findAllByPrice (Pageable pageable, String price) {
+        if (price.equals("무료")) {
+            Page<ExhibitionEntity> exhibitionEntities = exhibitionRepository.findAllByPrice(pageable, price);
+            return exhibitionEntities.map(exhibition -> ExhibitionDto.toDto(exhibition));
+        }
+
+        String p = "무료";
+
+        Page<ExhibitionEntity> exhibitionEntities = exhibitionRepository.findAllByPriceNot(pageable, p);
+        return exhibitionEntities.map(exhibition -> ExhibitionDto.toDto(exhibition));
+    }
+
     // 전시 상세 조회
     public ExhibitionDto getOne(long exhibitionId) {
         ExhibitionEntity selectedExhibition = exhibitionRepository.findById(exhibitionId)

--- a/src/test/java/com/dev/museummate/controller/ExhibitionControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/ExhibitionControllerTest.java
@@ -56,7 +56,7 @@ class ExhibitionControllerTest {
     @BeforeEach
     void set() {
         exhibitionDto1 = new ExhibitionDto(1l, "이집트미라전", "09:00", "18:00", "18000", "8세", "none",
-            "서울", "testgallery",
+            "서울", "testgallery", "string",
             new UserEntity(1l, "www@www.com", "1234", "moon", "112233", "010-0000-0000", "서울시", "서울시",UserRole.ROLE_USER),
             "20%", "80%", "20%", "20%", "20%", "20%", "20%",
             "www", "www", "www");
@@ -152,7 +152,7 @@ class ExhibitionControllerTest {
                                                                               .galleryName("test")
                                                                               .mainImgUrl("test")
                                                                               .noticeImgUrl("test")
-                                                                              .detailImgUrl("test")
+                                                                              .detailInfoImgUrl("test")
                                                                               .build();
 
 
@@ -176,7 +176,7 @@ class ExhibitionControllerTest {
                                                    .statAge50("test")
                                                    .mainImgUrl("test")
                                                    .noticeImgUrl("test")
-                                                   .detailImgUrl("test")
+                                                   .detailInfoImgUrl("test")
                                                    .build();
 
         given(exhibitionService.write(any(), anyString())).willReturn(exhibitionDto);
@@ -217,7 +217,7 @@ class ExhibitionControllerTest {
                                                                               .galleryName("test")
                                                                               .mainImgUrl("test")
                                                                               .noticeImgUrl("test")
-                                                                              .detailImgUrl("test")
+                                                                              .detailInfoImgUrl("test")
                                                                               .build();
 
         given(exhibitionService.write(any(), anyString())).willThrow(new AppException(ErrorCode.INVALID_TOKEN, ""));
@@ -278,7 +278,7 @@ class ExhibitionControllerTest {
         ExhibitionEditRequest exhibitionEditRequest = ExhibitionEditRequest.builder()
             .id(1l).name("이집트미라전").startAt("09:00").endAt("18:00").price("18000").ageLimit("8세").detailInfo("none")
             .galleryLocation("서울").galleryName("test").user(user).statMale("20%").statFemale("80%").mainImgUrl("www")
-            .noticeImgUrl("www").detailImgUrl("www")
+            .noticeImgUrl("www").detailInfoImgUrl("www")
             .build();
 
         given(exhibitionService.edit(any(), any(), any())).willReturn(exhibitionDto1);
@@ -314,7 +314,7 @@ class ExhibitionControllerTest {
             .andExpect(jsonPath("$.result.statAge50").exists())
             .andExpect(jsonPath("$.result.mainImgUrl").exists())
             .andExpect(jsonPath("$.result.noticeImgUrl").exists())
-            .andExpect(jsonPath("$.result.detailImgUrl").exists())
+            .andExpect(jsonPath("$.result.detailInfoImgUrl").exists())
             .andDo(print());
     }
 
@@ -331,7 +331,7 @@ class ExhibitionControllerTest {
         ExhibitionEditRequest exhibitionEditRequest = ExhibitionEditRequest.builder()
             .id(1l).name("이집트미라전").startAt("09:00").endAt("18:00").price("18000").ageLimit("8세").detailInfo("none")
             .galleryLocation("서울").galleryName("test").user(user).statMale("20%").statFemale("80%").mainImgUrl("www")
-            .noticeImgUrl("www").detailImgUrl("www")
+            .noticeImgUrl("www").detailInfoImgUrl("www")
             .build();
 
         given(exhibitionService.edit(any(), any(), any())).willThrow(new AppException(ErrorCode.DATABASE_ERROR, "데이터베이스 에러"));
@@ -357,7 +357,7 @@ class ExhibitionControllerTest {
         ExhibitionEditRequest exhibitionEditRequest = ExhibitionEditRequest.builder()
             .id(1l).name("이집트미라전").startAt("09:00").endAt("18:00").price("18000").ageLimit("8세").detailInfo("none")
             .galleryLocation("서울").galleryName("Test").user(user).statMale("20%").statFemale("80%").mainImgUrl("www")
-            .noticeImgUrl("www").detailImgUrl("www")
+            .noticeImgUrl("www").detailInfoImgUrl("www")
             .build();
 
         given(exhibitionService.edit(any(), any(), any())).willThrow(new AppException(ErrorCode.INVALID_PERMISSION, "작성자와 유저가 일치하지 않습니다."));

--- a/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
@@ -422,7 +422,7 @@ class GatheringControllerTest {
                                                            .statAge_50("temp").
                                                            mainImgUrl("temp").
                                                            noticeImgUrl("temp")
-                                                           .detailImgUrl("temp").build();
+                                                           .detailInfoImgUrl("temp").build();
 
             GatheringDto gatheringDto = GatheringDto.builder()
                                                     .id(gatheringId)


### PR DESCRIPTION
## :information_desk_person: 간단 소개
- 전시회를 유료 및 무료 카테고리로 분리하여 price별로 보여주기 위해 Exhibition Controller 및 Exhibition Repository 수정
- notice 누락되어 추가
- detailImgUrl -> detailInfoImgUrl으로 수정

## :heavy_check_mark: 작업 내용 설명
- [x]  전시회 price 단위로 구분하는 로직 추가
- [x]  notice 추가
- [x]  detailImgUrl -> detailInfoImgUrl으로 수정

## :bulb: 참고사항
로직 변경 등 리뷰어나 다른 팀원들이 참고해야 할 사항을 적어주세요.
