### PR TITLE
155 함께 전시 관람 승인 예외 추가

### DIFF
--- a/src/main/java/com/dev/museummate/service/GatheringService.java
+++ b/src/main/java/com/dev/museummate/service/GatheringService.java
@@ -134,6 +134,9 @@ public class GatheringService {
         ParticipantEntity participant = participantRepository.findById(participantId)
                                                              .orElseThrow(() -> new AppException(ErrorCode.PARTICIPANT_NOT_FOUND,
                                                                                                  "존재하지 않는 참여자 입니다."));
+        if (findGatheringPost.getClose().equals(Boolean.TRUE)) {
+            throw new AppException(ErrorCode.FORBIDDEN_ACCESS, "신청 인원이 전부 찼습니다.");
+        }
         participant.approveUser();
         participantRepository.save(participant);
 

--- a/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
+++ b/src/test/java/com/dev/museummate/controller/GatheringControllerTest.java
@@ -319,6 +319,20 @@ class GatheringControllerTest {
     }
 
     @Test
+    @DisplayName("참가 신청 승인 - 실패#5 최대 인원만큼 승인 한 뒤 또 승인 시도할 경우")
+    @WithMockUser
+    void approve_fail_5() throws Exception {
+
+        given(gatheringService.approve(any(), any(), any()))
+            .willThrow(new AppException(ErrorCode.FORBIDDEN_ACCESS, ""));
+
+        mockMvc.perform(get("/api/v1/gatherings/1/enroll/1")
+                            .with(csrf()))
+               .andDo(print())
+               .andExpect(status().isForbidden());
+    }
+
+    @Test
     @DisplayName("참가 신청 취소 - 성공")
     @WithMockUser
     void enroll_cancel_success() throws Exception {


### PR DESCRIPTION
## :information_desk_person: 간단 소개
설정한 최대 인원 만큼 승인을 한 뒤 또 승인을 시도할 경우 예외가 발생하도록 수정했습니다.

## :heavy_check_mark: 작업 내용 설명
approve()에서 게시글 상태가 닫혀 있을 경우 예외 발생하도록 처리

## :bulb: 참고사항
로직 변경 등 리뷰어나 다른 팀원들이 참고해야 할 사항을 적어주세요.
